### PR TITLE
use major version for default k8s info

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1822,8 +1822,8 @@
   }
  },
  "RancherDefaultK8sVersions": {
-  "2.3": "v1.15.2-rancher1-1",
-  "default": "v1.15.2-rancher1-1"
+  "2.3": "v1.15.x",
+  "default": "v1.15.x"
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.15.2-rancher1-1",

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -3,10 +3,14 @@ package rke
 import v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 
 func loadRancherDefaultK8sVersions() map[string]string {
+	/*
+	Just mention the major version, the latest minor version will be
+	automatically picked based on Rancher's max/min version information.
+	*/
 	return map[string]string{
-		"2.3": "v1.15.2-rancher1-1",
+		"2.3": "v1.15.x",
 		// rancher will use default if its version is absent
-		"default": "v1.15.2-rancher1-1",
+		"default": "v1.15.x",
 	}
 }
 


### PR DESCRIPTION
Rancher UI always picks the latest minor version based on the default k8s range. So we should only set major version and let it automatically pick the correct patch version based on min/max rancher info. 

https://github.com/rancher/rancher/issues/21598