### PR TITLE
remove validate for rancher default versions

### DIFF
--- a/rke/k8s_defaults.go
+++ b/rke/k8s_defaults.go
@@ -62,7 +62,6 @@ func init() {
 	DriverData.RancherDefaultK8sVersions = loadRancherDefaultK8sVersions()
 
 	validateDefaultPresent(DriverData.RKEDefaultK8sVersions)
-	validateDefaultPresent(DriverData.RancherDefaultK8sVersions)
 
 	DriverData.K8sVersionedTemplates = templates.LoadK8sVersionedTemplates()
 


### PR DESCRIPTION
Since versions are now only major versions, validate panics. Validation logic was added with template changes 

https://github.com/rancher/rancher/pull/22261