### PR TITLE
remove rancher suffix before testing range match

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -2095,22 +2095,22 @@
  "K8sVersionedTemplates": {
   "calico": {
    "\u003e=1.13.0 \u003c1.15.0": "calico-v1.13",
-   "\u003e=1.15.0 \u003c1.16.0": "calico-v1.15",
-   "\u003e=1.16.0": "calico-v1.16",
+   "\u003e=1.15.0 \u003c1.16.0-alpha": "calico-v1.15",
+   "\u003e=1.16.0-alpha": "calico-v1.16",
    "\u003e=1.8.0 \u003c1.13.0": "calico-v1.8"
   },
   "canal": {
    "\u003e=1.13.0 \u003c1.15.0": "canal-v1.13",
-   "\u003e=1.15.0 \u003c1.16.0": "canal-v1.15",
-   "\u003e=1.16.0": "canal-v1.16",
+   "\u003e=1.15.0 \u003c1.16.0-alpha": "canal-v1.15",
+   "\u003e=1.16.0-alpha": "canal-v1.16",
    "\u003e=1.8.0 \u003c1.13.0": "canal-v1.8"
   },
   "coreDNS": {
    "\u003e=1.8.0 \u003c1.16.0": "coredns-v1.8"
   },
   "flannel": {
-   "\u003e=1.15.0 \u003c1.16.0": "flannel-v1.15",
-   "\u003e=1.16.0": "flannel-v1.16",
+   "\u003e=1.15.0 \u003c1.16.0-alpha": "flannel-v1.15",
+   "\u003e=1.16.0-alpha": "flannel-v1.16",
    "\u003e=1.8.0 \u003c1.15.0": "flannel-v1.8"
   },
   "kubeDNS": {

--- a/rke/templates/templates.go
+++ b/rke/templates/templates.go
@@ -43,20 +43,20 @@ const (
 func LoadK8sVersionedTemplates() map[string]map[string]string {
 	return map[string]map[string]string{
 		Calico: {
-			">=1.16.0":         calicov116,
-			">=1.15.0 <1.16.0": calicov115,
+			">=1.16.0-alpha":         calicov116,
+			">=1.15.0 <1.16.0-alpha": calicov115,
 			">=1.13.0 <1.15.0": calicov113,
 			">=1.8.0 <1.13.0":  calicov18,
 		},
 		Canal: {
-			">=1.16.0":         canalv116,
-			">=1.15.0 <1.16.0": canalv115,
+			">=1.16.0-alpha":         canalv116,
+			">=1.15.0 <1.16.0-alpha": canalv115,
 			">=1.13.0 <1.15.0": canalv113,
 			">=1.8.0 <1.13.0":  canalv18,
 		},
 		Flannel: {
-			">=1.16.0":         flannelv116,
-			">=1.15.0 <1.16.0": flannelv115,
+			">=1.16.0-alpha":         flannelv116,
+			">=1.15.0 <1.16.0-alpha": flannelv115,
 			">=1.8.0 <1.15.0":  flannelv18,
 		},
 		CoreDNS: {


### PR DESCRIPTION
- semver considers -rancher as a rc version, so removing it before matching range. 
- 1.16-beta < 1.16.0, add >=1.16-alpha for correct fetching of templates.

- while writing data, we also print template information for all k8s versions so user can validate their k8s version is getting the correct key and template. 
something like, 
```
 "v1.16.0-beta.1-rancher1-1": {
  "calico": "range=>=1.16.0-alpha key=calico-v1.16",
  "canal": "range=>=1.16.0-alpha key=canal-v1.16",
  "coreDNS": "range=>=1.8.0 <1.16.0 key=coredns-v1.8",
  "flannel": "range=>=1.16.0-alpha key=flannel-v1.16",
  "kubeDNS": "range=>=1.8.0 <1.16.0 key=kubedns-v1.8",
  "metricsServer": "range=>=1.8.0 <1.16.0 key=metricsserver-v1.8",
  "nginxIngress": "range=>=1.8.0 <1.16.0 key=nginxingress-v1.8",
  "weave": "range=>=1.8.0 <1.16.0 key=weave-v1.8"
 },
```