### PR TITLE
Made calico init containers privileged in order to prevent issues on …

### DIFF
--- a/rke/templates/calico.go
+++ b/rke/templates/calico.go
@@ -317,6 +317,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/rke/templates/canal.go
+++ b/rke/templates/canal.go
@@ -360,6 +360,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
…SELinux systems. On these systems, the initialization container named `install-cni` lacks

```
securityContext:
  privileged: true
```

in its template definition, causing problems such as the one reported in rancher/rke#1691.

Manually editing the running DaemonSet, and adding the lines above, fixes the pod setup which enter the run state correctly. This suggest the template might be missing the above two lines.