### PR TITLE
relax template availability constraint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ replace (
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/rancher/types v0.0.0-20190930165650-6bbedae77a35
+	github.com/sirupsen/logrus v1.4.2
 )


### PR DESCRIPTION
old constraint: each plugin template must be present for all k8s versions

this is not very convenient if a new plugin is introduced only for new
versions, changed from error to warning