### PR TITLE
[dev-v2.4] Set new min versions for introduced k8s versions

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -4414,21 +4414,33 @@
    "maxRKEVersion": "1.0.0",
    "maxRancherVersion": "2.3.3"
   },
+  "v1.15.11-rancher1-1": {
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
+  },
   "v1.15.11-rancher1-2": {
-   "minRKEVersion": "1.0.4",
-   "minRancherVersion": "2.3.5"
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
   },
   "v1.15.5-rancher1-1": {
    "maxRKEVersion": "0.2.8",
    "maxRancherVersion": "2.2.9"
   },
+  "v1.16.8-rancher1-1": {
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
+  },
   "v1.16.8-rancher1-2": {
-   "minRKEVersion": "1.0.4",
-   "minRancherVersion": "2.3.5"
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
+  },
+  "v1.17.4-rancher1-1": {
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
   },
   "v1.17.4-rancher1-2": {
-   "minRKEVersion": "1.0.4",
-   "minRancherVersion": "2.3.5"
+   "minRKEVersion": "1.0.0",
+   "minRancherVersion": "2.3.3"
   },
   "v1.8": {
    "maxRKEVersion": "0.2.2",

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -67,17 +67,35 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MaxRancherVersion: "2.2.9",
 			MaxRKEVersion:     "0.2.8",
 		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		"v1.15.11-rancher1-1": {
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.15.11-rancher1-2": {
-			MinRancherVersion: "2.3.5",
-			MinRKEVersion:     "1.0.4",
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
 		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		"v1.16.8-rancher1-1": {
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.16.8-rancher1-2": {
-			MinRancherVersion: "2.3.5",
-			MinRKEVersion:     "1.0.4",
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
 		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		"v1.17.4-rancher1-1": {
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.17.4-rancher1-2": {
-			MinRancherVersion: "2.3.5",
-			MinRKEVersion:     "1.0.4",
+			MinRancherVersion: "2.3.3",
+			MinRKEVersion:     "1.0.0",
 		},
 		"v1.8.10-rancher1-1": {
 			DeprecateRKEVersion:     "0.2.2",


### PR DESCRIPTION
This should be the same as https://github.com/rancher/kontainer-driver-metadata/pull/195

https://github.com/rancher/rancher/issues/26327