### PR TITLE
Add versioninfo check for k8s versions

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -4451,6 +4451,10 @@
    "minRKEVersion": "1.0.0",
    "minRancherVersion": "2.3.3"
   },
+  "v1.15.11-rancher1-3": {
+   "minRKEVersion": "1.0.7",
+   "minRancherVersion": "2.3.7"
+  },
   "v1.15.5-rancher1-1": {
    "maxRKEVersion": "0.2.8",
    "maxRancherVersion": "2.2.9"
@@ -4463,6 +4467,10 @@
    "minRKEVersion": "1.0.0",
    "minRancherVersion": "2.3.3"
   },
+  "v1.16.8-rancher1-3": {
+   "minRKEVersion": "1.0.7",
+   "minRancherVersion": "2.3.7"
+  },
   "v1.17.4-rancher1-1": {
    "minRKEVersion": "1.0.0",
    "minRancherVersion": "2.3.3"
@@ -4470,6 +4478,10 @@
   "v1.17.4-rancher1-2": {
    "minRKEVersion": "1.0.0",
    "minRancherVersion": "2.3.3"
+  },
+  "v1.17.4-rancher1-3": {
+   "minRKEVersion": "1.0.7",
+   "minRancherVersion": "2.3.7"
   },
   "v1.8": {
    "maxRKEVersion": "0.2.2",

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -1935,7 +1935,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
 		},
-		// Enabled in Rancher v2.4.0
+		// Enabled in Rancher v2.3.7
 		// Reminder: Save template rancher1-1 for k8s 1.15 for Rancher v2.2.x due to WindowsPodInfraContainer image
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.15.11-rancher1-3": {
@@ -2295,7 +2295,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.7.1"),
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
 		},
-		// Enabled in Rancher v2.4.0
+		// Enabled in Rancher v2.3.7
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.16.8-rancher1-3": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.15-rancher1"),
@@ -2558,7 +2558,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.7.1"),
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
 		},
-		// Enabled in Rancher v2.4.0
+		// Enabled in Rancher v2.3.7
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.17.4-rancher1-3": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -78,6 +78,12 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MinRKEVersion:     "1.0.0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		// This version includes nodelocal dns only available in RKE v1.0.7 and up
+		"v1.15.11-rancher1-3": {
+			MinRancherVersion: "2.3.7",
+			MinRKEVersion:     "1.0.7",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.16.8-rancher1-1": {
 			MinRancherVersion: "2.3.3",
 			MinRKEVersion:     "1.0.0",
@@ -88,6 +94,12 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MinRKEVersion:     "1.0.0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		// This version includes nodelocal dns only available in RKE v1.0.7 and up
+		"v1.16.8-rancher1-3": {
+			MinRancherVersion: "2.3.7",
+			MinRKEVersion:     "1.0.7",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.17.4-rancher1-1": {
 			MinRancherVersion: "2.3.3",
 			MinRKEVersion:     "1.0.0",
@@ -96,6 +108,12 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.17.4-rancher1-2": {
 			MinRancherVersion: "2.3.3",
 			MinRKEVersion:     "1.0.0",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		// This version includes nodelocal dns only available in RKE v1.0.7 and up
+		"v1.17.4-rancher1-3": {
+			MinRancherVersion: "2.3.7",
+			MinRKEVersion:     "1.0.7",
 		},
 		"v1.8.10-rancher1-1": {
 			DeprecateRKEVersion:     "0.2.2",


### PR DESCRIPTION
- Adds a check so we don't forget to check version restrictions for new k8s versions
- Adds versions that failed the new check

@deniseschannon Are these the new nodelocal backported versions so they need `vX.X.7`?