### PR TITLE
Add support for version checking for templates

### DIFF
--- a/rke/templates/templates.go
+++ b/rke/templates/templates.go
@@ -49,6 +49,10 @@ const (
 	nodelocalv115 = "nodelocal-v1.15"
 )
 
+var TemplateIntroducedRanges = map[string][]string{
+	kdm.Nodelocal: {">=1.17.4-rancher1-1", ">=1.16.8-rancher1-1 <1.17.0-alpha", ">=1.15.11-rancher1-1 <1.16.0-alpha"},
+}
+
 func LoadK8sVersionedTemplates() map[string]map[string]string {
 	return map[string]map[string]string{
 		kdm.Calico: {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25704

After adding nodelocal template (which is only active for newly introduced k8s versions), there would be errors shown in `go generate` because not all versions would have a nodelocal template configured. This introduces a new map to specify what version ranges should be used to check for missing templates. This removes the annoying and not actionable errors.

This PR also disables printing the whole JSON to stdout, and removes `generating data.json` from the beginning and adds `finished generating data.json` at the end.