### PR TITLE
Add new k3s releases [dev-v2.4]

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,5 +1,8 @@
 releases:
-- version: v1.17.4+k3s1
+- version: v1.18.2+k3s1
+  minChannelServerVersion: v2.4.0-rc1
+  maxChannelServerVersion: v2.4.99
+- version: v1.17.5+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -4848,7 +4848,12 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.4+k3s1"
+    "version": "v1.18.2+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.4.99",
+    "minChannelServerVersion": "v2.4.0-rc1",
+    "version": "v1.17.5+k3s1"
    }
   ]
  }


### PR DESCRIPTION
Bumps k3s v1.17.4 to v1.17.5
Adds in release v1.18.2

Tested on Rancher v2.4.3 and confirmed working correctly.
(Point Rancher v2.4.3 rke-metadata-config setting to my forked data.json to test, ensure k3s upgrades work correctly)