### PR TITLE
Add new k3s releases [release-v2.4]

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,5 +1,4 @@
 releases:
-- version: v1.17.4+k3s1
+- version: v1.17.5+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
-

--- a/data/data.json
+++ b/data/data.json
@@ -4848,7 +4848,7 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.4+k3s1"
+    "version": "v1.17.5+k3s1"
    }
   ]
  }


### PR DESCRIPTION
Add ~v1.18.2 as version entry~ and bump v1.17.4 to v1.17.5
* ~Adds in v1.18.2 version~ After discussing with Denise we later agreed don't add in v1.18.2 yet as requires a go bump.
* Bumps v1.17.4 version entry to v1.17.5
* Tested in Rancher v2.4.2 and v2.4.3 with single-node k3s downstream cluster via my fork and is working correctly