### PR TITLE
Removing the tests from skipped set that have been fixed

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -4960,13 +4960,11 @@
     "1.2.6": "When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.",
     "4.2.10": "When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.",
     "4.2.6": "System level configurations are required prior to provisioning the cluster in order for this argument to be set to true.",
-    "5.1.5": "Kubernetes provides default service accounts to be used.",
     "5.2.2": "Enabling Pod Security Policy can cause applications to unexpectedly fail.",
     "5.2.3": "Enabling Pod Security Policy can cause applications to unexpectedly fail.",
     "5.2.4": "Enabling Pod Security Policy can cause applications to unexpectedly fail.",
     "5.2.5": "Enabling Pod Security Policy can cause applications to unexpectedly fail.",
-    "5.3.2": "Enabling Network Policies can prevent certain applications from communicating with each other.",
-    "5.6.4": "Kubernetes provides a default namespace."
+    "5.3.2": "Enabling Network Policies can prevent certain applications from communicating with each other."
    },
    "notApplicableChecks": {
     "1.1.1": "Clusters provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.\nAll configuration is passed in as arguments at container run time.",

--- a/rke/cis_config.go
+++ b/rke/cis_config.go
@@ -25,8 +25,6 @@ All configuration is passed in as arguments at container run time.`
 
 	// reasons for skipped checks
 	reasonForAlwaysPullImages                    = `Enabling AlwaysPullImages can use significant bandwidth.`
-	reasonForDefaultSA                           = `Kubernetes provides default service accounts to be used.`
-	reasonForDefaultNS                           = `Kubernetes provides a default namespace.`
 	reasonForEtcdDataDir                         = `A system service account is required for etcd data directory ownership. Refer to Rancher's hardening guide for more details on how to configure this ownership.`
 	reasonForEncryption                          = `Enabling encryption changes how data can be recovered as data is encrypted.`
 	reasonForEventRateLimit                      = `EventRateLimit needs to be tuned depending on the cluster.`
@@ -109,13 +107,11 @@ var rkeCIS15SkippedChecks = map[string]string{
 	"1.2.34": reasonForEncryption,
 	"4.2.6":  reasonForProtectKernelDefaults,
 	"4.2.10": reasonForKubeletServerCerts,
-	"5.1.5":  reasonForDefaultSA,
 	"5.2.2":  reasonForPSP,
 	"5.2.3":  reasonForPSP,
 	"5.2.4":  reasonForPSP,
 	"5.2.5":  reasonForPSP,
 	"5.3.2":  reasonForNetPol,
-	"5.6.4":  reasonForDefaultNS,
 }
 
 func loadCisConfigParams() map[string]v3.CisConfigParams {


### PR DESCRIPTION
Since these two tests have been fixed in rancher for rke clusters, they now pass on out of the box rke clusters.

We can remove them from skipped set.
