### PR TITLE
Bump k3s v1.17.4 to v1.17.5 stable

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,7 +1,4 @@
 releases:
-- version: v1.18.2+k3s1
-  minChannelServerVersion: v2.4.0-rc1
-  maxChannelServerVersion: v2.4.99
 - version: v1.17.5+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99

--- a/data/data.json
+++ b/data/data.json
@@ -4848,11 +4848,6 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.18.2+k3s1"
-   },
-   {
-    "maxChannelServerVersion": "v2.4.99",
-    "minChannelServerVersion": "v2.4.0-rc1",
     "version": "v1.17.5+k3s1"
    }
   ]


### PR DESCRIPTION
Removes v1.18.2 (https://github.com/rancher/kontainer-driver-metadata/pull/231)
Now, with these two PRs we are effectively only bumping k3s v1.17.4 to v1.17.5