### PR TITLE
Add k3s v1.17.4 back in and limit Rancher version scope

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,5 +1,8 @@
 releases:
-- version: v1.17.5+k3s1
+- version: v1.17.4+k3s1
   minChannelServerVersion: v2.4.0-rc1
+  maxChannelServerVersion: v2.4.2
+- version: v1.17.5+k3s1
+  minChannelServerVersion: v2.4.3-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -4846,8 +4846,13 @@
  "k3s": {
   "releases": [
    {
-    "maxChannelServerVersion": "v2.4.99",
+    "maxChannelServerVersion": "v2.4.2",
     "minChannelServerVersion": "v2.4.0-rc1",
+    "version": "v1.17.4+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.4.99",
+    "minChannelServerVersion": "v2.4.3-rc1",
     "version": "v1.17.5+k3s1"
    }
   ]


### PR DESCRIPTION
* Based on a slack conversation, we want v1.17.4 to stay in and target up to Rancher v2.4.2
* We want v1.17.5 in, but only for Rancher v2.4.3 and newer
* In the future, the maxChannelServerVersion would be changed to a lower version. This will become normal process.