### PR TITLE
Bump k8s 1.18.2 to 1.18.3

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -4300,7 +4300,7 @@
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.3"
   },
-  "v1.18.2-rancher1-1": {
+  "v1.18.3-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
    "alpine": "rancher/rke-tools:v0.1.56",
    "nginxProxy": "rancher/rke-tools:v0.1.56",
@@ -4313,7 +4313,7 @@
    "coredns": "rancher/coredns-coredns:1.6.9",
    "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
    "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
-   "kubernetes": "rancher/hyperkube:v1.18.2-rancher1",
+   "kubernetes": "rancher/hyperkube:v1.18.3-rancher1",
    "flannel": "rancher/coreos-flannel:v0.11.0-rancher1",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher5",
    "calicoNode": "rancher/calico-node:v3.13.0",
@@ -4588,7 +4588,7 @@
    "minRKEVersion": "1.0.7",
    "minRancherVersion": "2.3.7-rc0"
   },
-  "v1.18.2-rancher1-1": {
+  "v1.18.3-rancher1-1": {
    "minRKEVersion": "1.1.1-rc99",
    "minRancherVersion": "2.4.4-rc0"
   },
@@ -4624,7 +4624,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.18.2-rancher1-1"
+  "default": "v1.18.3-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -2601,9 +2601,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 		},
 		// Enabled in Rancher v2.4.4
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
-		"v1.18.2-rancher1-1": {
+		"v1.18.3-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
-			Kubernetes:                m("rancher/hyperkube:v1.18.2-rancher1"),
+			Kubernetes:                m("rancher/hyperkube:v1.18.3-rancher1"),
 			Alpine:                    m("rancher/rke-tools:v0.1.56"),
 			NginxProxy:                m("rancher/rke-tools:v0.1.56"),
 			CertDownloader:            m("rancher/rke-tools:v0.1.56"),

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -23,7 +23,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.18.2-rancher1-1",
+		"default": "v1.18.3-rancher1-1",
 	}
 }
 
@@ -118,7 +118,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.18.2-rancher1-1": {
+		"v1.18.3-rancher1-1": {
 			MinRancherVersion: "2.4.4-rc0",
 			MinRKEVersion:     "1.1.1-rc99",
 		},


### PR DESCRIPTION
Since 1.18 has not shipped yet, 1.18.2 will be directly replaced with 1.18.3.

Dependent on https://github.com/rancher/hyperkube/pull/110