### PR TITLE
Add k3s v1.17.5 and limit Rancher version scope

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,5 +1,8 @@
 releases:
 - version: v1.17.4+k3s1
   minChannelServerVersion: v2.4.0-rc1
+  maxChannelServerVersion: v2.4.2
+- version: v1.17.5+k3s1
+  minChannelServerVersion: v2.4.3-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -4994,9 +4994,14 @@
  "k3s": {
   "releases": [
    {
-    "maxChannelServerVersion": "v2.4.99",
+    "maxChannelServerVersion": "v2.4.2",
     "minChannelServerVersion": "v2.4.0-rc1",
     "version": "v1.17.4+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.4.99",
+    "minChannelServerVersion": "v2.4.3-rc1",
+    "version": "v1.17.5+k3s1"
    }
   ]
  }


### PR DESCRIPTION
This should bring dev-v2.5 branch up to date with dev-v2.4 and release-v2.4

* Brings dev-v2.5 branch up to date with dev-v2.4 and release-v2.4
* This adds in the v1.17.5+k3s release to channels.yaml
* We limit the scope of Rancher versions accordingly