### PR TITLE
Bump k3s to v1.17.5 and add v1.18.2 entry for R v2.4.4-rc1 or higher

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,8 +1,7 @@
 releases:
-- version: v1.17.4+k3s1
-  minChannelServerVersion: v2.4.0-rc1
-  maxChannelServerVersion: v2.4.2
 - version: v1.17.5+k3s1
-  minChannelServerVersion: v2.4.3-rc1
+  minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
-
+- version: v1.18.2+k3s1
+  minChannelServerVersion: v2.4.4-rc1
+  maxChannelServerVersion: v2.4.99

--- a/data/data.json
+++ b/data/data.json
@@ -5115,14 +5115,14 @@
  "k3s": {
   "releases": [
    {
-    "maxChannelServerVersion": "v2.4.2",
+    "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.4+k3s1"
+    "version": "v1.17.5+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.4.99",
-    "minChannelServerVersion": "v2.4.3-rc1",
-    "version": "v1.17.5+k3s1"
+    "minChannelServerVersion": "v2.4.4-rc1",
+    "version": "v1.18.2+k3s1"
    }
   ]
  }


### PR DESCRIPTION
* Bump to v1.17.5
* Add v1.18.2 for Rancher v2.4.4-rc1 min version

Related PR for dev-v2.4 branch: https://github.com/rancher/kontainer-driver-metadata/pull/254