### PR TITLE
Bump k3s versions - dev-v2.4

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,8 +1,8 @@
 releases:
-- version: v1.17.5+k3s1
+- version: v1.17.6+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
-- version: v1.18.2+k3s1
-  minChannelServerVersion: v2.4.4-rc1
+- version: v1.18.3+k3s1
+  minChannelServerVersion: v2.4.5-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -5124,12 +5124,12 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.5+k3s1"
+    "version": "v1.17.6+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.4.99",
-    "minChannelServerVersion": "v2.4.4-rc1",
-    "version": "v1.18.2+k3s1"
+    "minChannelServerVersion": "v2.4.5-rc1",
+    "version": "v1.18.3+k3s1"
    }
   ]
  }


### PR DESCRIPTION
* Bump the following k3s versions and increase min version for v1.18.x:
* v1.17.5 to v1.17.6
* v1.18.2 to v1.18.3
* Increase minChannelServerVersion for v1.18.x to v2.4.5-rc1 as we do not want v1.18.x to be an option in v2.4.4