### PR TITLE
adding flannel v0.12.0 and win1909

### DIFF
--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -2007,9 +2007,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			CoreDNS:                   m("coredns/coredns:1.3.1"),
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
 		},
-		// Enabled out of band after v2.4.3
-		// Reminder: Save template rancher1-1 for k8s 1.15 for Rancher v2.2.x due to WindowsPodInfraContainer image
-		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.7
+		// Enabled out of band after v2.4.4
 		"v1.15.12-rancher2-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.10-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.15.12-rancher2"),
@@ -2040,7 +2038,43 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			MetricsServer:             m("gcr.io/google_containers/metrics-server:v0.3.3"),
 			CoreDNS:                   m("coredns/coredns:1.3.1"),
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
-			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
+			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
+			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
+		},
+		// Enabled out of band after v2.4.5
+		// Reminder: Save template rancher1-1 for k8s 1.15 for Rancher v2.2.x due to WindowsPodInfraContainer image
+		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.7
+		"v1.15.12-rancher2-3": {
+			Etcd:                      m("quay.io/coreos/etcd:v3.3.10-rancher1"),
+			Kubernetes:                m("rancher/hyperkube:v1.15.12-rancher2"),
+			Alpine:                    m("rancher/rke-tools:v0.1.58"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.58"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.58"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.58"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
+			KubeDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.12.0"),
+			FlannelCNI:                m("rancher/flannel-cni:v0.3.0-rancher6"),
+			CalicoNode:                m("quay.io/calico/node:v3.13.4"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.13.4"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v3.13.4"),
+			CalicoControllers:         m("quay.io/calico/kube-controllers:v3.13.4"),
+			CalicoFlexVol:             m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			CanalNode:                 m("quay.io/calico/node:v3.13.4"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.13.4"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.12.0"),
+			CanalFlexVol:              m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.6.4"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.6.4"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:nginx-0.32.0-rancher1"),
+			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.5-rancher1"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server:v0.3.3"),
+			CoreDNS:                   m("coredns/coredns:1.3.1"),
+			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
+			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
 		// Experimental in Rancher v2.3.0


### PR DESCRIPTION
Will need v0.12.0 images pushed to docker hub

```
#!/bin/bash
# quay.io/coreos/flannel:v0.12.0
docker pull quay.io/coreos/flannel:v0.12.0-amd64
docker tag quay.io/coreos/flannel:v0.12.0-amd64 rancher/coreos-flannel:v0.12.0-amd64
docker push rancher/coreos-flannel:v0.12.0-amd64
docker pull quay.io/coreos/flannel:v0.12.0-arm64
docker tag quay.io/coreos/flannel:v0.12.0-arm64 rancher/coreos-flannel:v0.12.0-arm64
docker push rancher/coreos-flannel:v0.12.0-arm64
docker manifest create rancher/coreos-flannel:v0.12.0 rancher/coreos-flannel:v0.12.0-amd64 rancher/coreos-flannel:v0.12.0-arm64
docker manifest annotate rancher/coreos-flannel:v0.12.0 rancher/coreos-flannel:v0.12.0-amd64 --arch amd64
docker manifest annotate rancher/coreos-flannel:v0.12.0 rancher/coreos-flannel:v0.12.0-arm64 --arch arm64
docker manifest push -p rancher/coreos-flannel:v0.12.0
```