### PR TITLE
[2.5] New k8s versions v1.16.11, v1.17.7, v1.18.4

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1156,6 +1156,71 @@
     "v": "2"
    }
   },
+  "v1.16.11-rancher1-1": {
+   "etcd": {
+    "client-cert-auth": "true",
+    "peer-client-cert-auth": "true"
+   },
+   "kubeapi": {
+    "allow-privileged": "true",
+    "anonymous-auth": "false",
+    "bind-address": "0.0.0.0",
+    "enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,NodeRestriction,Priority,TaintNodesByCondition,PersistentVolumeClaimResize",
+    "insecure-port": "0",
+    "kubelet-preferred-address-types": "InternalIP,ExternalIP,Hostname",
+    "profiling": "false",
+    "requestheader-extra-headers-prefix": "X-Remote-Extra-",
+    "requestheader-group-headers": "X-Remote-Group",
+    "requestheader-username-headers": "X-Remote-User",
+    "runtime-config": "authorization.k8s.io/v1beta1=true",
+    "secure-port": "6443",
+    "service-account-lookup": "true",
+    "storage-backend": "etcd3",
+    "tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+   },
+   "kubelet": {
+    "address": "0.0.0.0",
+    "anonymous-auth": "false",
+    "authentication-token-webhook": "true",
+    "authorization-mode": "Webhook",
+    "cgroups-per-qos": "True",
+    "cni-bin-dir": "/opt/cni/bin",
+    "cni-conf-dir": "/etc/cni/net.d",
+    "enforce-node-allocatable": "",
+    "event-qps": "0",
+    "make-iptables-util-chains": "true",
+    "network-plugin": "cni",
+    "read-only-port": "0",
+    "resolv-conf": "/etc/resolv.conf",
+    "streaming-connection-idle-timeout": "30m",
+    "tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "v": "2",
+    "volume-plugin-dir": "/var/lib/kubelet/volumeplugins"
+   },
+   "kubeproxy": {
+    "healthz-bind-address": "127.0.0.1",
+    "v": "2"
+   },
+   "kubeController": {
+    "address": "0.0.0.0",
+    "allocate-node-cidrs": "true",
+    "allow-untagged-cloud": "true",
+    "configure-cloud-routes": "false",
+    "enable-hostpath-provisioner": "false",
+    "leader-elect": "true",
+    "node-monitor-grace-period": "40s",
+    "pod-eviction-timeout": "5m0s",
+    "profiling": "false",
+    "terminated-pod-gc-threshold": "1000",
+    "v": "2"
+   },
+   "scheduler": {
+    "address": "0.0.0.0",
+    "leader-elect": "true",
+    "profiling": "false",
+    "v": "2"
+   }
+  },
   "v1.16.3-rancher1-1": {
    "etcd": {
     "client-cert-auth": "true",
@@ -4053,7 +4118,7 @@
    "metricsServer": "rancher/metrics-server:v0.3.4",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.3"
   },
-  "v1.16.10-rancher2-2": {
+  "v1.16.11-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.3.15-rancher1",
    "alpine": "rancher/rke-tools:v0.1.58",
    "nginxProxy": "rancher/rke-tools:v0.1.58",
@@ -4066,7 +4131,7 @@
    "coredns": "rancher/coredns-coredns:1.6.2",
    "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
    "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
-   "kubernetes": "rancher/hyperkube:v1.16.10-rancher2",
+   "kubernetes": "rancher/hyperkube:v1.16.11-rancher1",
    "flannel": "rancher/coreos-flannel:v0.12.0",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
    "calicoNode": "rancher/calico-node:v3.13.4",
@@ -4689,7 +4754,7 @@
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.3"
   },
-  "v1.17.6-rancher2-2": {
+  "v1.17.7-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
    "alpine": "rancher/rke-tools:v0.1.58",
    "nginxProxy": "rancher/rke-tools:v0.1.58",
@@ -4702,7 +4767,7 @@
    "coredns": "rancher/coredns-coredns:1.6.5",
    "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
    "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
-   "kubernetes": "rancher/hyperkube:v1.17.6-rancher2",
+   "kubernetes": "rancher/hyperkube:v1.17.7-rancher1",
    "flannel": "rancher/coreos-flannel:v0.12.0",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
    "calicoNode": "rancher/calico-node:v3.13.4",
@@ -4755,7 +4820,7 @@
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.3"
   },
-  "v1.18.3-rancher2-2": {
+  "v1.18.4-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
    "alpine": "rancher/rke-tools:v0.1.58",
    "nginxProxy": "rancher/rke-tools:v0.1.58",
@@ -4768,7 +4833,7 @@
    "coredns": "rancher/coredns-coredns:1.6.9",
    "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
    "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
-   "kubernetes": "rancher/hyperkube:v1.18.3-rancher2",
+   "kubernetes": "rancher/hyperkube:v1.18.4-rancher1",
    "flannel": "rancher/coreos-flannel:v0.12.0",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
    "calicoNode": "rancher/calico-node:v3.13.4",
@@ -5047,7 +5112,7 @@
    "minRKEVersion": "1.1.2-rc0",
    "minRancherVersion": "2.4.4-rc0"
   },
-  "v1.16.10-rancher2-2": {
+  "v1.16.11-rancher1-1": {
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
@@ -5079,7 +5144,7 @@
    "minRKEVersion": "1.1.2-rc0",
    "minRancherVersion": "2.4.4-rc0"
   },
-  "v1.17.6-rancher2-2": {
+  "v1.17.7-rancher1-1": {
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
@@ -5087,7 +5152,7 @@
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
-  "v1.18.3-rancher2-2": {
+  "v1.18.4-rancher1-1": {
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
@@ -5129,7 +5194,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.18.3-rancher2-2"
+  "default": "v1.18.4-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -2476,9 +2476,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 		},
 		// Enabled in Rancher v2.4.5
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
-		"v1.16.10-rancher2-2": {
+		"v1.16.11-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.15-rancher1"),
-			Kubernetes:                m("rancher/hyperkube:v1.16.10-rancher2"),
+			Kubernetes:                m("rancher/hyperkube:v1.16.11-rancher1"),
 			Alpine:                    m("rancher/rke-tools:v0.1.58"),
 			NginxProxy:                m("rancher/rke-tools:v0.1.58"),
 			CertDownloader:            m("rancher/rke-tools:v0.1.58"),
@@ -2810,9 +2810,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 		},
 		// Enabled in Rancher v2.4.5
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
-		"v1.17.6-rancher2-2": {
+		"v1.17.7-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
-			Kubernetes:                m("rancher/hyperkube:v1.17.6-rancher2"),
+			Kubernetes:                m("rancher/hyperkube:v1.17.7-rancher1"),
 			Alpine:                    m("rancher/rke-tools:v0.1.58"),
 			NginxProxy:                m("rancher/rke-tools:v0.1.58"),
 			CertDownloader:            m("rancher/rke-tools:v0.1.58"),
@@ -2880,9 +2880,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 		},
 		// Enabled in Rancher v2.4.5
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
-		"v1.18.3-rancher2-2": {
+		"v1.18.4-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
-			Kubernetes:                m("rancher/hyperkube:v1.18.3-rancher2"),
+			Kubernetes:                m("rancher/hyperkube:v1.18.4-rancher1"),
 			Alpine:                    m("rancher/rke-tools:v0.1.58"),
 			NginxProxy:                m("rancher/rke-tools:v0.1.58"),
 			CertDownloader:            m("rancher/rke-tools:v0.1.58"),

--- a/rke/k8s_service_options.go
+++ b/rke/k8s_service_options.go
@@ -85,6 +85,14 @@ func loadK8sVersionServiceOptions() map[string]v3.KubernetesServicesOptions {
 			Kubeproxy:      getKubeProxyOptions(),
 			Scheduler:      getSchedulerOptions(),
 		},
+		"v1.16.11-rancher1-1": {
+			Etcd:           getETCDOptions(),
+			KubeAPI:        getKubeAPIOptions116(),
+			Kubelet:        getKubeletOptions116(),
+			KubeController: getKubeControllerOptions(),
+			Kubeproxy:      getKubeProxyOptions(),
+			Scheduler:      getSchedulerOptions(),
+		},
 		"v1.16": {
 			KubeAPI:        getKubeAPIOptions116(),
 			Kubelet:        getKubeletOptions116(),

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -29,7 +29,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.18.3-rancher2-2",
+		"default": "v1.18.4-rancher1-1",
 	}
 }
 
@@ -130,7 +130,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.16.10-rancher2-2": {
+		"v1.16.11-rancher1-1": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",
 		},
@@ -159,7 +159,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.17.6-rancher2-2": {
+		"v1.17.7-rancher1-1": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",
 		},
@@ -171,7 +171,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.18.3-rancher2-2": {
+		"v1.18.4-rancher1-1": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",
 		},


### PR DESCRIPTION
NOTE: this can't be merged until the upstream releases `v1.18.4`, which as of now has not been released