### PR TITLE
Change default CIS benchmark version

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -5602,19 +5602,19 @@
  },
  "CisConfigParams": {
   "default": {
-   "benchmarkVersion": "rke-cis-1.4"
+   "benchmarkVersion": "rke-cis-1.5"
   },
   "v1.15": {
-   "benchmarkVersion": "rke-cis-1.4"
+   "benchmarkVersion": "rke-cis-1.5"
   },
   "v1.16": {
-   "benchmarkVersion": "rke-cis-1.4"
+   "benchmarkVersion": "rke-cis-1.5"
   },
   "v1.17": {
-   "benchmarkVersion": "rke-cis-1.4"
+   "benchmarkVersion": "rke-cis-1.5"
   },
   "v1.18": {
-   "benchmarkVersion": "rke-cis-1.4"
+   "benchmarkVersion": "rke-cis-1.5"
   }
  },
  "CisBenchmarkVersionInfo": {

--- a/rke/cis_config.go
+++ b/rke/cis_config.go
@@ -121,19 +121,19 @@ var rkeCIS15SkippedChecks = map[string]string{
 func loadCisConfigParams() map[string]kdm.CisConfigParams {
 	return map[string]kdm.CisConfigParams{
 		"default": {
-			BenchmarkVersion: "rke-cis-1.4",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 		"v1.15": {
-			BenchmarkVersion: "rke-cis-1.4",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 		"v1.16": {
-			BenchmarkVersion: "rke-cis-1.4",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 		"v1.17": {
-			BenchmarkVersion: "rke-cis-1.4",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 		"v1.18": {
-			BenchmarkVersion: "rke-cis-1.4",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 	}
 }


### PR DESCRIPTION
Adding one more PR to change the default CIS version on dev-v2.5
Copy of https://github.com/rancher/kontainer-driver-metadata/pull/286

