### PR TITLE
Bump k3s versions to v1.17.9 and v1.18.6

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,8 +1,8 @@
 releases:
-- version: v1.17.7+k3s1
+- version: v1.17.9+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
-- version: v1.18.4+k3s1
+- version: v1.18.6+k3s1
   minChannelServerVersion: v2.4.5-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -5720,12 +5720,12 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.7+k3s1"
+    "version": "v1.17.9+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.4+k3s1"
+    "version": "v1.18.6+k3s1"
    }
   ]
  }


### PR DESCRIPTION
Required for 7/15 security fixes

Bump k3s versions to v1.17.9+k3s1 and v1.18.6+k3s1
Go generate

Signed-off-by: David Nuzik <david.nuzik@rancher.com>