### PR TITLE
[dev-v2.4] update min version for v1.16.10-rancher2-2

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -5318,8 +5318,8 @@
    "minRancherVersion": "2.4.4-rc0"
   },
   "v1.16.10-rancher2-2": {
-   "minRKEVersion": "1.1.3-rc0",
-   "minRancherVersion": "2.4.5-rc0"
+   "minRKEVersion": "1.1.2-rc0",
+   "minRancherVersion": "2.4.4-rc0"
   },
   "v1.16.13-rancher1-1": {
    "minRKEVersion": "1.1.2-rc0",
@@ -5354,8 +5354,8 @@
    "minRancherVersion": "2.4.4-rc0"
   },
   "v1.17.6-rancher2-2": {
-   "minRKEVersion": "1.1.3-rc0",
-   "minRancherVersion": "2.4.5-rc0"
+   "minRKEVersion": "1.1.2-rc0",
+   "minRancherVersion": "2.4.4-rc0"
   },
   "v1.17.9-rancher1-1": {
    "minRKEVersion": "1.1.2-rc0",

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -2510,7 +2510,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled in Rancher v2.4.5
+		// Enabled out band for Rancher v2.4.4 with Rancher v2.4.5
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.16.10-rancher2-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.15-rancher1"),
@@ -2545,7 +2545,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled out of band for Rancher v2.3.8+
+		// Enabled out of band for Rancher v2.4.4+
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.16.13-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.15-rancher1"),
@@ -2879,7 +2879,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.3"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled in Rancher v2.4.5
+		// Enabled out of band for v2.4.4 with Rancher v2.4.5
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.17.6-rancher2-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
@@ -2914,7 +2914,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled out of band for Rancher v2.3.8+
+		// Enabled out of band for Rancher v2.4.4+
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.17.9-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -141,8 +141,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.16.10-rancher2-2": {
-			MinRancherVersion: "2.4.5-rc0",
-			MinRKEVersion:     "1.1.3-rc0",
+			MinRancherVersion: "2.4.4-rc0",
+			MinRKEVersion:     "1.1.2-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
@@ -176,8 +176,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.17.6-rancher2-2": {
-			MinRancherVersion: "2.4.5-rc0",
-			MinRKEVersion:     "1.1.3-rc0",
+			MinRancherVersion: "2.4.4-rc0",
+			MinRKEVersion:     "1.1.2-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up


### PR DESCRIPTION
Since we have v1.16.13 with min v2.4.4, it seems inconsistent to have previous version at 2.4.5. It won't change anything for v2.4.4 because v1.16.13 is now the latest v1.16 patch version. Same logic for v1.17.6