### PR TITLE
Add missing flannel placeholders to canal templates

### DIFF
--- a/rke/templates/canal.go
+++ b/rke/templates/canal.go
@@ -806,7 +806,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---
@@ -1422,7 +1424,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---
@@ -2052,7 +2056,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---
@@ -2752,7 +2758,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---
@@ -3273,7 +3281,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 
@@ -3913,7 +3923,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 
@@ -4728,7 +4740,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---
@@ -5428,7 +5442,9 @@ data:
     {
       "Network": "{{.ClusterCIDR}}",
       "Backend": {
-        "Type": "{{.FlannelBackend.Type}}"
+        "Type": "{{.FlannelBackend.Type}}",
+        "VNI": {{.FlannelBackend.VNI}},
+        "Port": {{.FlannelBackend.Port}}
       }
     }
 ---


### PR DESCRIPTION
The ConfigMap templates used for the flannel plugin include the ability to specify the VXLAN VNI and port.

The equivalent templates for canal are missing the template fields for these values so when specified in the cluster.yml, they are not rendered.

This adds the missing template placeholders to the canal templates.