### PR TITLE
Bump rke-tools to v0.1.61

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -3988,10 +3988,10 @@
   },
   "v1.15.12-rancher2-5": {
    "etcd": "rancher/coreos-etcd:v3.3.10-rancher1",
-   "alpine": "rancher/rke-tools:v0.1.60",
-   "nginxProxy": "rancher/rke-tools:v0.1.60",
-   "certDownloader": "rancher/rke-tools:v0.1.60",
-   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.60",
+   "alpine": "rancher/rke-tools:v0.1.61",
+   "nginxProxy": "rancher/rke-tools:v0.1.61",
+   "certDownloader": "rancher/rke-tools:v0.1.61",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.61",
    "kubedns": "rancher/k8s-dns-kube-dns:1.15.0",
    "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.0",
    "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.0",
@@ -4447,10 +4447,10 @@
   },
   "v1.16.13-rancher1-2": {
    "etcd": "rancher/coreos-etcd:v3.3.15-rancher1",
-   "alpine": "rancher/rke-tools:v0.1.60",
-   "nginxProxy": "rancher/rke-tools:v0.1.60",
-   "certDownloader": "rancher/rke-tools:v0.1.60",
-   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.60",
+   "alpine": "rancher/rke-tools:v0.1.61",
+   "nginxProxy": "rancher/rke-tools:v0.1.61",
+   "certDownloader": "rancher/rke-tools:v0.1.61",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.61",
    "kubedns": "rancher/k8s-dns-kube-dns:1.15.0",
    "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.0",
    "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.0",
@@ -5149,10 +5149,10 @@
   },
   "v1.17.9-rancher1-2": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
-   "alpine": "rancher/rke-tools:v0.1.60",
-   "nginxProxy": "rancher/rke-tools:v0.1.60",
-   "certDownloader": "rancher/rke-tools:v0.1.60",
-   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.60",
+   "alpine": "rancher/rke-tools:v0.1.61",
+   "nginxProxy": "rancher/rke-tools:v0.1.61",
+   "certDownloader": "rancher/rke-tools:v0.1.61",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.61",
    "kubedns": "rancher/k8s-dns-kube-dns:1.15.0",
    "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.0",
    "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.0",
@@ -5281,10 +5281,10 @@
   },
   "v1.18.6-rancher1-2": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
-   "alpine": "rancher/rke-tools:v0.1.60",
-   "nginxProxy": "rancher/rke-tools:v0.1.60",
-   "certDownloader": "rancher/rke-tools:v0.1.60",
-   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.60",
+   "alpine": "rancher/rke-tools:v0.1.61",
+   "nginxProxy": "rancher/rke-tools:v0.1.61",
+   "certDownloader": "rancher/rke-tools:v0.1.61",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.61",
    "kubedns": "rancher/k8s-dns-kube-dns:1.15.2",
    "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.2",
    "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.2",
@@ -5572,7 +5572,7 @@
    "minRancherVersion": "2.4.6-rc0"
   },
   "v1.15.12-rancher2-5": {
-   "minRKEVersion": "1.1.4-rc0",
+   "minRKEVersion": "1.1.5-rc0",
    "minRancherVersion": "2.4.6-rc0"
   },
   "v1.15.5-rancher1-1": {
@@ -5592,8 +5592,8 @@
    "minRancherVersion": "2.4.4-rc0"
   },
   "v1.16.13-rancher1-2": {
-   "minRKEVersion": "1.1.2-rc0",
-   "minRancherVersion": "2.4.4-rc0"
+   "minRKEVersion": "1.1.5-rc0",
+   "minRancherVersion": "2.4.6-rc0"
   },
   "v1.16.8-rancher1-1": {
    "minRKEVersion": "1.0.0",
@@ -5632,8 +5632,8 @@
    "minRancherVersion": "2.4.4-rc0"
   },
   "v1.17.9-rancher1-2": {
-   "minRKEVersion": "1.1.2-rc0",
-   "minRancherVersion": "2.4.4-rc0"
+   "minRKEVersion": "1.1.5-rc0",
+   "minRancherVersion": "2.4.6-rc0"
   },
   "v1.18.3-rancher2-1": {
    "minRKEVersion": "1.1.3-rc0",
@@ -5648,8 +5648,8 @@
    "minRancherVersion": "2.4.5-rc0"
   },
   "v1.18.6-rancher1-2": {
-   "minRKEVersion": "1.1.3-rc0",
-   "minRancherVersion": "2.4.5-rc0"
+   "minRKEVersion": "1.1.5-rc0",
+   "minRancherVersion": "2.4.6-rc0"
   },
   "v1.8": {
    "maxRKEVersion": "0.2.2",

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -2121,10 +2121,10 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 		"v1.15.12-rancher2-5": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.10-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.15.12-rancher2"),
-			Alpine:                    m("rancher/rke-tools:v0.1.60"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.60"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.60"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.60"),
+			Alpine:                    m("rancher/rke-tools:v0.1.61"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.61"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.61"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.61"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
@@ -2616,15 +2616,15 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled out of band for Rancher v2.4.4+
+		// Enabled in Rancher v2.4.6
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.16.13-rancher1-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.15-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.16.13-rancher1"),
-			Alpine:                    m("rancher/rke-tools:v0.1.60"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.60"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.60"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.60"),
+			Alpine:                    m("rancher/rke-tools:v0.1.61"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.61"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.61"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.61"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
@@ -3020,15 +3020,15 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled out of band for Rancher v2.4.4+
+		// Enabled in Rancher v2.4.6
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.17.9-rancher1-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.17.9-rancher1"),
-			Alpine:                    m("rancher/rke-tools:v0.1.60"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.60"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.60"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.60"),
+			Alpine:                    m("rancher/rke-tools:v0.1.61"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.61"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.61"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.61"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
@@ -3160,15 +3160,15 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
-		// Enabled out of band for Rancher v2.4.5+
+		// Enabled in Rancher v2.4.6
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.18.6-rancher1-2": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.4.3-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.18.6-rancher1"),
-			Alpine:                    m("rancher/rke-tools:v0.1.60"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.60"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.60"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.60"),
+			Alpine:                    m("rancher/rke-tools:v0.1.61"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.61"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.61"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.61"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.2"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.2"),

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -120,7 +120,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// It also includes ingress-nginx 0.32.0
 		"v1.15.12-rancher2-5": {
 			MinRancherVersion: "2.4.6-rc0",
-			MinRKEVersion:     "1.1.4-rc0",
+			MinRKEVersion:     "1.1.5-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.16.8-rancher1-1": {
@@ -160,8 +160,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.16.13-rancher1-2": {
-			MinRancherVersion: "2.4.4-rc0",
-			MinRKEVersion:     "1.1.2-rc0",
+			MinRancherVersion: "2.4.6-rc0",
+			MinRKEVersion:     "1.1.5-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		"v1.17.4-rancher1-1": {
@@ -201,8 +201,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.17.9-rancher1-2": {
-			MinRancherVersion: "2.4.4-rc0",
-			MinRKEVersion:     "1.1.2-rc0",
+			MinRancherVersion: "2.4.6-rc0",
+			MinRKEVersion:     "1.1.5-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
@@ -225,8 +225,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.18.6-rancher1-2": {
-			MinRancherVersion: "2.4.5-rc0",
-			MinRKEVersion:     "1.1.3-rc0",
+			MinRancherVersion: "2.4.6-rc0",
+			MinRKEVersion:     "1.1.5-rc0",
 		},
 		"v1.8.10-rancher1-1": {
 			DeprecateRKEVersion:     "0.2.2",


### PR DESCRIPTION
New rke-tools version: `v0.1.61`