### PR TITLE
K3S - Update k3s v1.17 and v1.18 versions

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,8 +1,8 @@
 releases:
-- version: v1.17.9+k3s1
+- version: v1.17.11+k3s1
   minChannelServerVersion: v2.4.0-rc1
   maxChannelServerVersion: v2.4.99
-- version: v1.18.6+k3s1
+- version: v1.18.8+k3s1
   minChannelServerVersion: v2.4.5-rc1
   maxChannelServerVersion: v2.4.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -6063,12 +6063,12 @@
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.9+k3s1"
+    "version": "v1.17.11+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.4.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.6+k3s1"
+    "version": "v1.18.8+k3s1"
    }
   ]
  },


### PR DESCRIPTION
* Updates v1.17.9 to v1.17.11 and v1.18.6 to v1.18.8
* Note, v1.17.10 and v1.18.7 were skipped as upstream was having issues with these releases and taged new versions.

* go generate