### PR TITLE
[dev-2.4] Update k3s  v1.17.12, v1.18.9 and add v1.19.2

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,8 +1,10 @@
 releases:
-- version: v1.17.11+k3s1
-  minChannelServerVersion: v2.4.0-rc1
-  maxChannelServerVersion: v2.4.99
-- version: v1.18.8+k3s1
-  minChannelServerVersion: v2.4.5-rc1
-  maxChannelServerVersion: v2.4.99
-
+  - version: v1.17.12+k3s1
+    minChannelServerVersion: v2.4.0-rc1
+    maxChannelServerVersion: v2.5.99
+  - version: v1.18.9+k3s1
+    minChannelServerVersion: v2.4.5-rc1
+    maxChannelServerVersion: v2.5.99
+  - version: v1.19.2+k3s1
+    minChannelServerVersion: v2.5.0-rc1
+    maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -6339,14 +6339,19 @@
  "k3s": {
   "releases": [
    {
-    "maxChannelServerVersion": "v2.4.99",
+    "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.11+k3s1"
+    "version": "v1.17.12+k3s1"
    },
    {
-    "maxChannelServerVersion": "v2.4.99",
+    "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.8+k3s1"
+    "version": "v1.18.9+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.5.99",
+    "minChannelServerVersion": "v2.5.0-rc1",
+    "version": "v1.19.2+k3s1"
    }
   ]
  }


### PR DESCRIPTION
- Bump k3s versions to v1.17.12+k3s1 and v1.18.8+k3s1
- Add k3s version v1.19.2
- Change max version to v2.5.99 
- Go generate

