### PR TITLE
[2.5] Update ingress version in K8S v1.19.1

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -5703,7 +5703,7 @@
    "weaveNode": "weaveworks/weave-kube:2.7.0",
    "weaveCni": "weaveworks/weave-npc:2.7.0",
    "podInfraContainer": "rancher/pause:3.2",
-   "ingress": "rancher/nginx-ingress-controller:nginx-0.32.0-rancher1",
+   "ingress": "rancher/nginx-ingress-controller:nginx-0.35.0-rancher1",
    "ingressBackend": "rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1",
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.4"

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -3397,7 +3397,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WeaveNode:                 m("weaveworks/weave-kube:2.7.0"),
 			WeaveCNI:                  m("weaveworks/weave-npc:2.7.0"),
 			PodInfraContainer:         m("gcr.io/google_containers/pause:3.2"),
-			Ingress:                   m("rancher/nginx-ingress-controller:nginx-0.32.0-rancher1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:nginx-0.35.0-rancher1"),
 			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.5-rancher1"),
 			MetricsServer:             m("gcr.io/google_containers/metrics-server:v0.3.6"),
 			CoreDNS:                   m("coredns/coredns:1.7.0"),


### PR DESCRIPTION
Update k8s v1.19.1 to include new ingress image: `rancher/nginx-ingress-controller:nginx-0.35.0-rancher1` 