### PR TITLE
update rke2 release tag

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.9+rke2
+  - version: v1.18.9+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -6669,7 +6669,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.9+rke2"
+    "version": "v1.18.9+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
This pr updates rke2 release tag to `v1.18.9+rke2r1` instead of `v1.18.9+rke2`
related issue : https://github.com/rancher/rke2/issues/383