### PR TITLE
[2.4] bump k3s versions 10/30/20 Patch Releases

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.17.13+k3s1
+  - version: v1.17.13+k3s2
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.10+k3s1
+  - version: v1.18.10+k3s2
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.3+k3s1
+  - version: v1.19.3+k3s2
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -6776,17 +6776,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.13+k3s1"
+    "version": "v1.17.13+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.10+k3s1"
+    "version": "v1.18.10+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.3+k3s1"
+    "version": "v1.19.3+k3s2"
    }
   ]
  }


### PR DESCRIPTION
This pr updates the k3s versions for Oct 30 releases, (+k3s2) releases
issue: rancher/k3s#2460

