### PR TITLE
bump rke2 version

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.10+rke2r1
+  - version: v1.18.11+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -6959,7 +6959,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.10+rke2r1"
+    "version": "v1.18.11+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
This pr updates rke2 version to v1.18.11+rke2r1

