### PR TITLE
[dev-2.5]Bump k3s 1.18

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -2,7 +2,7 @@ releases:
   - version: v1.17.14+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.11+k3s1
+  - version: v1.18.12+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
   - version: v1.19.4+k3s1

--- a/data/data.json
+++ b/data/data.json
@@ -7010,7 +7010,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.11+k3s1"
+    "version": "v1.18.12+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",


### PR DESCRIPTION
upstream is skipping v1.18.11, this pr updates k3s version to v1.18.12