### PR TITLE
Bump k3s for urgent releases

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.11+rke2r1
+  - version: v1.18.10+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.17.14+k3s1
+  - version: v1.17.14+k3s2
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
   - version: v1.18.12+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.4+k3s1
+  - version: v1.19.3+k3s3
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7113,7 +7113,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.14+k3s1"
+    "version": "v1.17.14+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
@@ -7123,7 +7123,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.4+k3s1"
+    "version": "v1.19.3+k3s3"
    }
   ]
  },
@@ -7132,7 +7132,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.11+rke2r1"
+    "version": "v1.18.10+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
**Rationale for these specific versions we are changing to:**

Decrease RKE2 version from v1.18.11+rke2r1 to v1.18.10+rke2r1 because we originally planned to release RKE2 before a KDM release. Now that we need to urgently get K3s releases out to fix a bug in Kine we will release KDM before RKE2 is ready. (RKE2 is not affected by this bug as it does not leverage kine)

Bump v1.17.14+k3s1 to v1.17.14+k3s2 because before we found this severe bug in kine we already had v1.17.14+k3s1 out. Now we need a +k3s2 of this which will contain the fix.

Leave v1.18.12+k3s1 as it is because it was already rev'ed in prior PRs and not yet released before the severe kine fix.

Bump v1.19.4+k3s1 to v1.19.3+k3s3 actually because we are having build issues with v1.19.4+k3s2 and because we need this urgent kine fix, we will get a v1.19.3+k3s3 release out because we cannot wait to fix this build issue, thus we need a +k3s3 release of v1.19.3

Sorry for the confusion but this is the best I could do to explain the reasoning behind these changes which at first glance may appear incorrect. They should all be correct.
