### PR TITLE
[2.5] Bump k3s version for urgent release tags 

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.17.14+k3s1
+  - version: v1.17.14+k3s2
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
   - version: v1.18.12+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.4+k3s1
+  - version: v1.19.3+k3s3
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7113,7 +7113,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.14+k3s1"
+    "version": "v1.17.14+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
@@ -7123,7 +7123,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.4+k3s1"
+    "version": "v1.19.3+k3s3"
    }
   ]
  },


### PR DESCRIPTION
Bump v1.17.14+k3s1 to v1.17.14+k3s2 because before we found this severe bug in kine we already had v1.17.14+k3s1 out. Now we need a +k3s2 of this which will contain the fix.

Leave v1.18.12+k3s1 as it is because it was already rev'ed in prior PRs and not yet released before the severe kine fix.

Bump v1.19.4+k3s1 to v1.19.3+k3s3 actually because we are having build issues with v1.19.4+k3s2 and because we need this urgent kine fix, we will get a v1.19.3+k3s3 release out because we cannot wait to fix this build issue, thus we need a +k3s3 release of v1.19.3

