### PR TITLE
Revert rke2 version

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.11+rke2r1
+  - version: v1.18.10+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -7132,7 +7132,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.11+rke2r1"
+    "version": "v1.18.10+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
Decrease RKE2 version from v1.18.11+rke2r1 to v1.18.10+rke2r1 because we originally planned to release RKE2 before a KDM release. Now that we need to urgently get K3s releases out to fix a bug in Kine we will release KDM before RKE2 is ready. (RKE2 is not affected by this bug as it does not leverage kine)

