### PR TITLE
[channelserver] bump k3s and rke2 versions 

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.10+rke2r1
+  - version: v1.18.12+rke2r2
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.17.14+k3s2
+  - version: v1.17.14+k3s3
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.12+k3s1
+  - version: v1.18.12+k3s2
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.3+k3s3
+  - version: v1.19.4+k3s2
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7113,17 +7113,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.14+k3s2"
+    "version": "v1.17.14+k3s3"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.12+k3s1"
+    "version": "v1.18.12+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.3+k3s3"
+    "version": "v1.19.4+k3s2"
    }
   ]
  },
@@ -7132,7 +7132,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.10+rke2r1"
+    "version": "v1.18.12+rke2r2"
    }
   ]
  }


### PR DESCRIPTION
This pr updates k3s and rke2 versions in kdm for https://github.com/k3s-io/k3s/issues/2618 and https://github.com/rancher/rke2/issues/557