### PR TITLE
[dev-v2.3] Add kdm template v1.17.16-rancher1-1

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -4595,6 +4595,39 @@
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.4"
   },
+  "v1.17.16-rancher1-1": {
+   "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
+   "alpine": "rancher/rke-tools:v0.1.68",
+   "nginxProxy": "rancher/rke-tools:v0.1.68",
+   "certDownloader": "rancher/rke-tools:v0.1.68",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.68",
+   "kubedns": "rancher/k8s-dns-kube-dns:1.15.0",
+   "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.0",
+   "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.0",
+   "kubednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
+   "coredns": "rancher/coredns-coredns:1.6.5",
+   "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
+   "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
+   "kubernetes": "rancher/hyperkube:v1.17.16-rancher1",
+   "flannel": "rancher/coreos-flannel:v0.12.0",
+   "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
+   "calicoNode": "rancher/calico-node:v3.13.4",
+   "calicoCni": "rancher/calico-cni:v3.13.4",
+   "calicoControllers": "rancher/calico-kube-controllers:v3.13.4",
+   "calicoCtl": "rancher/calico-ctl:v3.13.4",
+   "calicoFlexVol": "rancher/calico-pod2daemon-flexvol:v3.13.4",
+   "canalNode": "rancher/calico-node:v3.13.4",
+   "canalCni": "rancher/calico-cni:v3.13.4",
+   "canalFlannel": "rancher/coreos-flannel:v0.12.0",
+   "canalFlexVol": "rancher/calico-pod2daemon-flexvol:v3.13.4",
+   "weaveNode": "weaveworks/weave-kube:2.6.4",
+   "weaveCni": "weaveworks/weave-npc:2.6.4",
+   "podInfraContainer": "rancher/pause:3.1",
+   "ingress": "rancher/nginx-ingress-controller:nginx-0.35.0-rancher2",
+   "ingressBackend": "rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1",
+   "metricsServer": "rancher/metrics-server:v0.3.6",
+   "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.4"
+  },
   "v1.17.2-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
    "alpine": "rancher/rke-tools:v0.1.52",
@@ -5176,6 +5209,10 @@
    "minRancherVersion": "2.3.8-rc0"
   },
   "v1.17.14-rancher1-1": {
+   "minRKEVersion": "1.0.9-rc0",
+   "minRancherVersion": "2.3.8-rc0"
+  },
+  "v1.17.16-rancher1-1": {
    "minRKEVersion": "1.0.9-rc0",
    "minRancherVersion": "2.3.8-rc0"
   },

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -3018,6 +3018,42 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
+		// Enabled in Rancher v2.3.10
+		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
+		// Reminder: This template doesn't contain ACI images which are in templates for v2.5.x
+		"v1.17.16-rancher1-1": {
+			Etcd:                      m("rancher/coreos-etcd:v3.4.3-rancher1"),
+			Kubernetes:                m("rancher/hyperkube:v1.17.16-rancher1"),
+			Alpine:                    m("rancher/rke-tools:v0.1.68"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.68"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.68"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.68"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
+			KubeDNSAutoscaler:         m("rancher/cluster-proportional-autoscaler:1.7.1"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.12.0"),
+			FlannelCNI:                m("rancher/flannel-cni:v0.3.0-rancher6"),
+			CalicoNode:                m("quay.io/calico/node:v3.13.4"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.13.4"),
+			CalicoControllers:         m("quay.io/calico/kube-controllers:v3.13.4"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v3.13.4"),
+			CalicoFlexVol:             m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			CanalNode:                 m("quay.io/calico/node:v3.13.4"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.13.4"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.12.0"),
+			CanalFlexVol:              m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.6.4"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.6.4"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:nginx-0.35.0-rancher2"),
+			IngressBackend:            m("rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server:v0.3.6"),
+			CoreDNS:                   m("coredns/coredns:1.6.5"),
+			CoreDNSAutoscaler:         m("rancher/cluster-proportional-autoscaler:1.7.1"),
+			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
+			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
+		},
 		// k8s version from 2.1.x release with old rke-tools to allow upgrade from 2.1.x clusters
 		// without all clusters being restarted
 		"v1.11.9-rancher1-3": {

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -187,6 +187,10 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MinRancherVersion: "2.3.8-rc0",
 			MinRKEVersion:     "1.0.9-rc0",
 		},
+		"v1.17.16-rancher1-1": {
+			MinRancherVersion: "2.3.8-rc0",
+			MinRKEVersion:     "1.0.9-rc0",
+		},
 		"v1.8.10-rancher1-1": {
 			DeprecateRKEVersion:     "0.2.2",
 			DeprecateRancherVersion: "2.2",


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30223

Same template as in v2.5, but ACI images removed