### PR TITLE
[dev-2.5] Bump rke2 v1.19.5

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,5 +1,5 @@
 releases:
-  - version: v1.18.13+rke2r1
+  - version: v1.19.5+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
 

--- a/data/data.json
+++ b/data/data.json
@@ -7276,7 +7276,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.13+rke2r1"
+    "version": "v1.19.5+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
this pr bumps rke2 version to v1.19.5+rke2r1
issue: https://github.com/rancher/rke2/issues/610
