### PR TITLE
Add availability for rke2 v1.19 and v1.18

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,4 +1,7 @@
 releases:
+  - version: v1.18.13+rke2r1
+    minChannelServerVersion: v2.5.0-rc1
+    maxChannelServerVersion: v2.5.99
   - version: v1.19.5+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7276,6 +7276,11 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
+    "version": "v1.18.13+rke2r1"
+   },
+   {
+    "maxChannelServerVersion": "v2.5.99",
+    "minChannelServerVersion": "v2.5.0-rc1",
     "version": "v1.19.5+rke2r1"
    }
   ]


### PR DESCRIPTION
this pr adds support for rke2 v1.18 and 1.19 to be available for upgrades in rancher