### PR TITLE
[dev-2.5] K3s jan 13th

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,10 +1,13 @@
 releases:
-  - version: v1.17.15+k3s1
+  - version: v1.17.17+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.13+k3s1
+  - version: v1.18.15+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.5+k3s2
+  - version: v1.19.7+k3s1
     minChannelServerVersion: v2.5.0-rc1
+    maxChannelServerVersion: v2.5.99
+  - version: v1.20.2+k3s1
+    minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7257,17 +7257,22 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.0-rc1",
-    "version": "v1.17.15+k3s1"
+    "version": "v1.17.17+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.13+k3s1"
+    "version": "v1.18.15+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.5+k3s2"
+    "version": "v1.19.7+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.5.99",
+    "minChannelServerVersion": "v2.5.6-rc1",
+    "version": "v1.20.2+k3s1"
    }
   ]
  },


### PR DESCRIPTION
this pr bumps k3s versions v1.17.17 , v1.18.15 ,v1.19.7 and v1.20.2
issue : https://github.com/k3s-io/k3s/issues/2795