### PR TITLE
[dev-2.5] Rke2 jan 13th

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,7 +1,7 @@
 releases:
-  - version: v1.18.13+rke2r1
+  - version: v1.18.15+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.5+rke2r1
+  - version: v1.19.7+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7276,12 +7276,12 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.13+rke2r1"
+    "version": "v1.18.15+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.5+rke2r1"
+    "version": "v1.19.7+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
this pr bumps rke2 versions 1.18.5 and 1.19.7
issue : https://github.com/rancher/rke2/issues/657