### PR TITLE
[dev-2.5] Bump k3s versions

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -2,12 +2,12 @@ releases:
   - version: v1.17.17+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.15+k3s1
+  - version: v1.18.16+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.7+k3s1
+  - version: v1.19.8+k3s1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.2+k3s1
+  - version: v1.20.4+k3s1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -7923,17 +7923,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.15+k3s1"
+    "version": "v1.18.16+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.7+k3s1"
+    "version": "v1.19.8+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.2+k3s1"
+    "version": "v1.20.4+k3s1"
    }
   ]
  },


### PR DESCRIPTION
v1.18.16+k3s1
v1.19.8+k3s1	
~v1.20.3+k3s1~
v1.20.4+k3s1