### PR TITLE
[2.5]rke-cis-1.6 profile is not supported for CIS v1 feature, only supported by the v2 chart

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -7812,7 +7812,7 @@
    "benchmarkVersion": "rke-cis-1.5"
   },
   "v1.20": {
-   "benchmarkVersion": "rke-cis-1.6"
+   "benchmarkVersion": "rke-cis-1.5"
   }
  },
  "CisBenchmarkVersionInfo": {

--- a/rke/cis_config.go
+++ b/rke/cis_config.go
@@ -139,7 +139,7 @@ func loadCisConfigParams() map[string]kdm.CisConfigParams {
 			BenchmarkVersion: "rke-cis-1.5",
 		},
 		"v1.20": {
-			BenchmarkVersion: "rke-cis-1.6",
+			BenchmarkVersion: "rke-cis-1.5",
 		},
 	}
 }


### PR DESCRIPTION
This PR is added to revert the change made by this https://github.com/rancher/kontainer-driver-metadata/pull/482 which made "rke-cis-1.6" as the default cis profile for k8s 1.20 

But we don't support CIS 1.6 version via KDM for CIS v1. CIS 1.6 is only available for CIS v2 chart.

https://github.com/rancher/rancher/issues/31343