### PR TITLE
[dev-v2.4] Add v1.17.17-rancher2-1

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -5676,6 +5676,39 @@
    "metricsServer": "rancher/metrics-server:v0.3.6",
    "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.4"
   },
+  "v1.17.17-rancher2-1": {
+   "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
+   "alpine": "rancher/rke-tools:v0.1.71",
+   "nginxProxy": "rancher/rke-tools:v0.1.71",
+   "certDownloader": "rancher/rke-tools:v0.1.71",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.71",
+   "kubedns": "rancher/k8s-dns-kube-dns:1.15.0",
+   "dnsmasq": "rancher/k8s-dns-dnsmasq-nanny:1.15.0",
+   "kubednsSidecar": "rancher/k8s-dns-sidecar:1.15.0",
+   "kubednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
+   "coredns": "rancher/coredns-coredns:1.6.5",
+   "corednsAutoscaler": "rancher/cluster-proportional-autoscaler:1.7.1",
+   "nodelocal": "rancher/k8s-dns-node-cache:1.15.7",
+   "kubernetes": "rancher/hyperkube:v1.17.17-rancher2",
+   "flannel": "rancher/coreos-flannel:v0.12.0",
+   "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
+   "calicoNode": "rancher/calico-node:v3.13.4",
+   "calicoCni": "rancher/calico-cni:v3.13.4",
+   "calicoControllers": "rancher/calico-kube-controllers:v3.13.4",
+   "calicoCtl": "rancher/calico-ctl:v3.13.4",
+   "calicoFlexVol": "rancher/calico-pod2daemon-flexvol:v3.13.4",
+   "canalNode": "rancher/calico-node:v3.13.4",
+   "canalCni": "rancher/calico-cni:v3.13.4",
+   "canalFlannel": "rancher/coreos-flannel:v0.12.0",
+   "canalFlexVol": "rancher/calico-pod2daemon-flexvol:v3.13.4",
+   "weaveNode": "weaveworks/weave-kube:2.6.4",
+   "weaveCni": "weaveworks/weave-npc:2.6.4",
+   "podInfraContainer": "rancher/pause:3.1",
+   "ingress": "rancher/nginx-ingress-controller:nginx-0.35.0-rancher2",
+   "ingressBackend": "rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1",
+   "metricsServer": "rancher/metrics-server:v0.3.6",
+   "windowsPodInfraContainer": "rancher/kubelet-pause:v0.1.6"
+  },
   "v1.17.2-rancher1-1": {
    "etcd": "rancher/coreos-etcd:v3.4.3-rancher1",
    "alpine": "rancher/rke-tools:v0.1.52",
@@ -6748,6 +6781,10 @@
    "minRancherVersion": "2.4.4-rc0"
   },
   "v1.17.17-rancher1-1": {
+   "minRKEVersion": "1.1.2-rc0",
+   "minRancherVersion": "2.4.4-rc0"
+  },
+  "v1.17.17-rancher2-1": {
    "minRKEVersion": "1.1.2-rc0",
    "minRancherVersion": "2.4.4-rc0"
   },

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -3585,6 +3585,42 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.4"),
 			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
 		},
+		// Enabled in Rancher v2.4.14
+		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
+		// Reminder: This template doesn't contain ACI images which are in templates for v2.5.x
+		"v1.17.17-rancher2-1": {
+			Etcd:                      m("rancher/coreos-etcd:v3.4.3-rancher1"),
+			Kubernetes:                m("rancher/hyperkube:v1.17.17-rancher2"),
+			Alpine:                    m("rancher/rke-tools:v0.1.71"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.71"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.71"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.71"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns:1.15.0"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar:1.15.0"),
+			KubeDNSAutoscaler:         m("rancher/cluster-proportional-autoscaler:1.7.1"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.12.0"),
+			FlannelCNI:                m("rancher/flannel-cni:v0.3.0-rancher6"),
+			CalicoNode:                m("quay.io/calico/node:v3.13.4"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.13.4"),
+			CalicoControllers:         m("quay.io/calico/kube-controllers:v3.13.4"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v3.13.4"),
+			CalicoFlexVol:             m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			CanalNode:                 m("quay.io/calico/node:v3.13.4"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.13.4"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.12.0"),
+			CanalFlexVol:              m("quay.io/calico/pod2daemon-flexvol:v3.13.4"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.6.4"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.6.4"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:nginx-0.35.0-rancher2"),
+			IngressBackend:            m("rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server:v0.3.6"),
+			CoreDNS:                   m("coredns/coredns:1.6.5"),
+			CoreDNSAutoscaler:         m("rancher/cluster-proportional-autoscaler:1.7.1"),
+			WindowsPodInfraContainer:  m("rancher/kubelet-pause:v0.1.6"),
+			Nodelocal:                 m("k8s.gcr.io/k8s-dns-node-cache:1.15.7"),
+		},
 		// Enabled in Rancher v2.4.4
 		// Reminder: This template contains Nodelocal image which isn't in templates before v2.3.6
 		"v1.18.3-rancher2-1": {

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -299,6 +299,12 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
+		"v1.17.17-rancher2-1": {
+			MinRancherVersion: "2.4.4-rc0",
+			MinRKEVersion:     "1.1.2-rc0",
+		},
+		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
+		// This version includes nodelocal dns only available in RKE v1.0.7 and up
 		"v1.18.3-rancher2-1": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/31223

Updates
hyperkube to v1.17.17-rancher2
rke-tools to v0.1.71
windowsPodInfra to v0.1.6