### PR TITLE
[dev-2.5] March 19th k3s rke2 patch releases

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,7 +1,10 @@
 releases:
-  - version: v1.18.16+rke2r1
+  - version: v1.18.17+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.8+rke2r1
+  - version: v1.19.9+rke2r1
     minChannelServerVersion: v2.5.0-rc1
+    maxChannelServerVersion: v2.5.99
+  - version: v1.20.5+rke2r1
+    minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/channels.yaml
+++ b/channels.yaml
@@ -2,12 +2,12 @@ releases:
   - version: v1.17.17+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.16+k3s1
+  - version: v1.18.17+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.8+k3s1
+  - version: v1.19.9+k3s1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.4+k3s1
+  - version: v1.20.5+k3s1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -8226,17 +8226,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.16+k3s1"
+    "version": "v1.18.17+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.8+k3s1"
+    "version": "v1.19.9+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.4+k3s1"
+    "version": "v1.20.5+k3s1"
    }
   ]
  },
@@ -8245,12 +8245,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.16+rke2r1"
+    "version": "v1.18.17+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.8+rke2r1"
+    "version": "v1.19.9+rke2r1"
+   },
+   {
+    "maxChannelServerVersion": "v2.5.99",
+    "minChannelServerVersion": "v2.5.6-rc1",
+    "version": "v1.20.5+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
This pr adds the new patch versions for k3s and rke2
rke2 issues : https://github.com/rancher/rke2/issues/721 , https://github.com/rancher/rke2/issues/720 and https://github.com/rancher/rke2/issues/719
k3s issues : https://github.com/k3s-io/k3s/issues/2973 , https://github.com/k3s-io/k3s/issues/2975 and https://github.com/k3s-io/k3s/issues/2976