### PR TITLE
[dev-v2.5] Update default k8s version

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -7737,7 +7737,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.20.5-rancher1-1"
+  "default": "v1.20.5-rancher1-2"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -37,7 +37,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.20.5-rancher1-1",
+		"default": "v1.20.5-rancher1-2",
 	}
 }
 


### PR DESCRIPTION
We should update the default to the latest in `dev-v2.5`

This is also required for testing this issue:
- https://github.com/rancher/rancher/issues/30565