### PR TITLE
[dev-2.5] K3s-rke2 April patches

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.18.17+rke2r1
+  - version: v1.18.18+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.9+rke2r1
+  - version: v1.19.10+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.5+rke2r1
+  - version: v1.20.6+rke2r1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/channels.yaml
+++ b/channels.yaml
@@ -2,12 +2,12 @@ releases:
   - version: v1.17.17+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.17+k3s1
+  - version: v1.18.18+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.9+k3s1
+  - version: v1.19.10+k3s1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.5+k3s1
+  - version: v1.20.6+k3s1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -8686,17 +8686,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.17+k3s1"
+    "version": "v1.18.18+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.9+k3s1"
+    "version": "v1.19.10+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.5+k3s1"
+    "version": "v1.20.6+k3s1"
    }
   ]
  },
@@ -8705,17 +8705,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.17+rke2r1"
+    "version": "v1.18.18+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.9+rke2r1"
+    "version": "v1.19.10+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.5+rke2r1"
+    "version": "v1.20.6+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
This pr updates the k3s-rke2 patches to v1.18.18 , v1.19.10 and v1.20.6