### PR TITLE
[dev-v2.5] rke2: 1.18.20, 1.19.12, 1.20.8

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,10 +1,10 @@
 releases:
-  - version: v1.18.19+rke2r1
+  - version: v1.18.20+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.11+rke2r1
+  - version: v1.19.12+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.7+rke2r2
+  - version: v1.20.8+rke2r1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -8953,17 +8953,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.18.19+rke2r1"
+    "version": "v1.18.20+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.11+rke2r1"
+    "version": "v1.19.12+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.7+rke2r2"
+    "version": "v1.20.8+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
- rke2: 1.18.20, 1.19.12, 1.20.8
- go generate
