### PR TITLE
[dev-v2.6] k3s: 1.18.20, 1.19.12, 1.20.8, 1.21.2

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,14 +1,14 @@
 releases:
-  - version: v1.17.17+k3s1
+  - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.18.17+k3s1
+  - version: v1.19.12+k3s1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.19.9+k3s1
+  - version: v1.20.8+k3s1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.21.1+k3s1
+  - version: v1.21.2+k3s1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: &serverArgs-v1

--- a/data/data.json
+++ b/data/data.json
@@ -9061,11 +9061,6 @@
    {
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.0-alpha1",
-    "version": "v1.17.17+k3s1"
-   },
-   {
-    "maxChannelServerVersion": "v2.6.99",
-    "minChannelServerVersion": "v2.6.0-alpha1",
     "version": "v1.18.20+k3s1"
    },
    {

--- a/data/data.json
+++ b/data/data.json
@@ -9066,12 +9066,17 @@
    {
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.0-alpha1",
-    "version": "v1.18.17+k3s1"
+    "version": "v1.18.20+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.0-alpha1",
-    "version": "v1.19.9+k3s1"
+    "version": "v1.19.12+k3s1"
+   },
+   {
+    "maxChannelServerVersion": "v2.6.99",
+    "minChannelServerVersion": "v2.6.0-alpha1",
+    "version": "v1.20.8+k3s1"
    },
    {
     "agentArgs": {
@@ -9199,7 +9204,7 @@
       "type": "array"
      }
     },
-    "version": "v1.21.1+k3s1"
+    "version": "v1.21.2+k3s1"
    }
   ]
  },


### PR DESCRIPTION
- k3s: 1.18.20, 1.19.12, 1.20.8, 1.21.2
- removed 1.17 for 2.6
- go generate