### PR TITLE
[dev-v2.5] k3s: 1.18.20, 1.19.12, 1.20.8

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -2,12 +2,12 @@ releases:
   - version: v1.17.17+k3s1
     minChannelServerVersion: v2.4.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.18.19+k3s1
+  - version: v1.18.20+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.11+k3s1
+  - version: v1.19.12+k3s1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.7+k3s1
+  - version: v1.20.8+k3s1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -8934,17 +8934,17 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.4.5-rc1",
-    "version": "v1.18.19+k3s1"
+    "version": "v1.18.20+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.11+k3s1"
+    "version": "v1.19.12+k3s1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.7+k3s1"
+    "version": "v1.20.8+k3s1"
    }
   ]
  },


### PR DESCRIPTION
- k3s: 1.18.20, 1.19.12, 1.20.8
- go generate
