### PR TITLE
fixed default v1.20 version

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -8537,7 +8537,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.20.8-rancher1-1"
+  "default": "v1.20.9-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -37,7 +37,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.20.8-rancher1-1",
+		"default": "v1.20.9-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2619

RKE is defaulting to v1.20.8 even though the latest version is v1.20.9.  The default version was never updated.