### PR TITLE
[dev-v2.6] bump hyperkube to v1.21.3, rke-tools v0.1.78

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -8029,12 +8029,12 @@
    "aciGbpServerContainer": "noiro/gbp-server:5.1.1.0.1ae238a",
    "aciOpflexServerContainer": "noiro/opflex-server:5.1.1.0.1ae238a"
   },
-  "v1.21.1-rancher3-1": {
+  "v1.21.3-rancher1-1": {
    "etcd": "rancher/mirrored-coreos-etcd:v3.4.16-rancher1",
-   "alpine": "rancher/rke-tools:v0.1.76",
-   "nginxProxy": "rancher/rke-tools:v0.1.76",
-   "certDownloader": "rancher/rke-tools:v0.1.76",
-   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.76",
+   "alpine": "rancher/rke-tools:v0.1.78",
+   "nginxProxy": "rancher/rke-tools:v0.1.78",
+   "certDownloader": "rancher/rke-tools:v0.1.78",
+   "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.78",
    "kubedns": "rancher/mirrored-k8s-dns-kube-dns:1.17.4",
    "dnsmasq": "rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.4",
    "kubednsSidecar": "rancher/mirrored-k8s-dns-sidecar:1.17.4",
@@ -8042,7 +8042,7 @@
    "coredns": "rancher/mirrored-coredns-coredns:1.8.4",
    "corednsAutoscaler": "rancher/mirrored-cluster-proportional-autoscaler:1.8.3",
    "nodelocal": "rancher/mirrored-k8s-dns-node-cache:1.18.0",
-   "kubernetes": "rancher/hyperkube:v1.21.1-rancher3",
+   "kubernetes": "rancher/hyperkube:v1.21.3-rancher1",
    "flannel": "rancher/mirrored-coreos-flannel:v0.14.0",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
    "calicoNode": "rancher/mirrored-calico-node:v3.19.1",
@@ -8672,7 +8672,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.21.1-rancher3-1"
+  "default": "v1.21.3-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -5516,13 +5516,13 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			Nodelocal:                 "rancher/mirrored-k8s-dns-node-cache:1.15.13",
 		},
 		// Enabled in v2.6
-		"v1.21.1-rancher3-1": {
+		"v1.21.3-rancher1-1": {
 			Etcd:                      "rancher/mirrored-coreos-etcd:v3.4.16-rancher1",
-			Kubernetes:                "rancher/hyperkube:v1.21.1-rancher3",
-			Alpine:                    "rancher/rke-tools:v0.1.76",
-			NginxProxy:                "rancher/rke-tools:v0.1.76",
-			CertDownloader:            "rancher/rke-tools:v0.1.76",
-			KubernetesServicesSidecar: "rancher/rke-tools:v0.1.76",
+			Kubernetes:                "rancher/hyperkube:v1.21.3-rancher1",
+			Alpine:                    "rancher/rke-tools:v0.1.78",
+			NginxProxy:                "rancher/rke-tools:v0.1.78",
+			CertDownloader:            "rancher/rke-tools:v0.1.78",
+			KubernetesServicesSidecar: "rancher/rke-tools:v0.1.78",
 			KubeDNS:                   "rancher/mirrored-k8s-dns-kube-dns:1.17.4",
 			DNSmasq:                   "rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.4",
 			KubeDNSSidecar:            "rancher/mirrored-k8s-dns-sidecar:1.17.4",

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -38,7 +38,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.21.1-rancher3-1",
+		"default": "v1.21.3-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
* Bump hyperkube to latest v1.21 -> v1.21.3
* Bump rke-tools to v0.1.78 for cri-dockerd fix: https://github.com/rancher/rancher/issues/33445