### PR TITLE
Revert rke2 1.20 release

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -5,6 +5,6 @@ releases:
   - version: v1.19.13+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.9+rke2r1
+  - version: v1.20.8+rke2r1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -9055,7 +9055,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.9+rke2r1"
+    "version": "v1.20.8+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
Revert 1.20 release of rke2 from .9 to .8. There is a bad bug in 1.20.9 and we want to avoid having folks upgrade to it.