### PR TITLE
revert rke2 1.20.9

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -5,6 +5,6 @@ releases:
   - version: v1.19.13+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.9+rke2r1
+  - version: v1.20.8+rke2r1
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2,7 +2,7 @@ releases:
   - version: v1.18.20+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.13+rke2r1
+  - version: v1.19.12+rke2r1
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
   - version: v1.20.8+rke2r1

--- a/data/data.json
+++ b/data/data.json
@@ -9050,7 +9050,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.13+rke2r1"
+    "version": "v1.19.12+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.5.99",

--- a/data/data.json
+++ b/data/data.json
@@ -9055,7 +9055,7 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.9+rke2r1"
+    "version": "v1.20.8+rke2r1"
    }
   ]
  }


### PR DESCRIPTION
Revert to rke2 1.20.8.
We're temporarily removing 1.20.9 from rancher until this bug is fixed: https://github.com/rancher/rke2/issues/1530