### PR TITLE
[dev-v2.6] Validate released k8s version images to data.json

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,12 +1,12 @@
-FROM golang:1.16.2-alpine3.12
+FROM golang:1.16.6-alpine3.14
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
+RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq
 RUN go get golang.org/x/tools/cmd/goimports
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1; \
     fi
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG

--- a/check-kdm-data.sh
+++ b/check-kdm-data.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+RELEASES="release-v2.6 release-v2.5"
+
+for RELEASE in $RELEASES; do
+    echo "Images check for released Rancher k8s versions for ${RELEASE}"
+
+    RELEASE_URL="https://releases.rancher.com/kontainer-driver-metadata/${RELEASE}/data.json"
+
+    # Released data file
+    RELEASEDATAFILE=$(curl --connect-timeout 60 --max-time 60 -s ${RELEASE_URL})
+
+    # Build released versions checksums file
+    echo "Creating kdm-released-${RELEASE}.txt from https://releases.rancher.com/kontainer-driver-metadata/${RELEASE}/data.json"
+    for K8SVERSION in $(echo $RELEASEDATAFILE | jq -r '.K8sVersionRKESystemImages | keys[]'); do
+        CHECKSUM=$(echo $RELEASEDATAFILE | jq -r '.K8sVersionRKESystemImages["'"$K8SVERSION"'"]' | sha256sum | awk '{ print $1 }')
+        echo "${K8SVERSION} ${CHECKSUM}" >> "kdm-released-${RELEASE}.txt"
+    done
+
+    # Compare to current data
+    echo "Comparing images for released versions in kdm-released-${RELEASE}.txt to data/data.json"
+    DEVDATAFILE=$(cat data/data.json)
+
+    while read -r K8SVERSION DATACHECKSUM; do
+        DEVCHECKSUM=$(echo $DEVDATAFILE | jq -r '.K8sVersionRKESystemImages["'"$K8SVERSION"'"]' | sha256sum | awk '{ print $1 }')
+        if [ "${DEVCHECKSUM}" != "${DATACHECKSUM}" ]; then
+            echo "Images checksum for released k8s version ${K8SVERSION} not equal (data.json: ${DEVCHECKSUM}) vs (kdm-released-${RELEASE}.txt: ${DATACHECKSUM})"
+            echo "We cannot change images in a released Rancher k8s version, please create a new Rancher k8s version to make the change (e.g. create v1.20.9-rancher1-2 with new images instead of changing v1.20.9-rancher1-1)"
+            exit 1
+        fi
+    done < "kdm-released-${RELEASE}.txt"
+done

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -20,3 +20,6 @@ if [ -n "$DIRTY" ]; then
     git status
     exit 1
 fi
+
+echo Checking if released versions are not changed
+bash check-kdm-data.sh


### PR DESCRIPTION
This checks if the released Rancher k8s versions are not changed in the local `data/data.json` (which causes an unintentional upgrade and should be solved by adding a new Rancher k8s versions instead of changing existing versions)