### PR TITLE
Revert rke2 versions v1.19.13 to .12 and v1.20.9 to .8

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2,10 +2,10 @@ releases:
   - version: v1.18.20+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.19.13+rke2r1
+  - version: v1.19.12+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.20.9+rke2r1
+  - version: v1.20.8+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
   - version: v1.21.3-rc4+rke2r2

--- a/data/data.json
+++ b/data/data.json
@@ -9455,12 +9455,12 @@
    {
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.0-alpha1",
-    "version": "v1.19.13+rke2r1"
+    "version": "v1.19.12+rke2r1"
    },
    {
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.0-alpha1",
-    "version": "v1.20.9+rke2r1"
+    "version": "v1.20.8+rke2r1"
    },
    {
     "agentArgs": {


### PR DESCRIPTION
Revert broken rke2 versions for dev-v2.6
https://github.com/rancher/rancher/issues/33942
https://github.com/rancher/rancher/issues/33946

Signed-off-by: dereknola <derek.nola@suse.com>