### PR TITLE
Update the rke2 charts to v3.19.2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -97,10 +97,10 @@ releases:
         version: v3.13.300-build2021022306
       rke2-calico:
         repo: rancher-rke2-charts
-        verion: v3.19.1-105
+        version: v3.19.2-201
       rke2-calico-crd:
         repo: rancher-rke2-charts
-        version: v1.0.005
+        version: v1.0.101
       rke2-coredns:
         repo: rancher-rke2-charts
         version: 1.10.101-build2021022304

--- a/data/data.json
+++ b/data/data.json
@@ -9518,11 +9518,11 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "verion": "v3.19.1-105"
+      "version": "v3.19.2-201"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",
-      "version": "v1.0.005"
+      "version": "v1.0.101"
      },
      "rke2-canal": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
This update fixes the issue with the ClusterIP by disabling VXLAN tunnel checksum offload on kernels <v5.7. Works around projectcalico/calico#3145.

Signed-off-by: Manuel Buil <mbuil@suse.com>