### PR TITLE
rke2: Update the chart to v3.19.2-202

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -97,7 +97,7 @@ releases:
         version: v3.13.300-build2021022306
       rke2-calico:
         repo: rancher-rke2-charts
-        version: v3.19.2-201
+        version: v3.19.2-202
       rke2-calico-crd:
         repo: rancher-rke2-charts
         version: v1.0.101

--- a/data/data.json
+++ b/data/data.json
@@ -9518,7 +9518,7 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "version": "v3.19.2-201"
+      "version": "v3.19.2-202"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
The chart v3.19.2-202 contains a fix for the IPAMConfig name. Before
that change, the IPAMConfig was not consumed by Calico.

The chart change was submitted as rancher/rke2-charts#132

Ref: rancher/rke2#1624

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>