### PR TITLE
RKE2 v1.21.3 rc6+rke2r2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -8,7 +8,7 @@ releases:
   - version: v1.20.9+rke2r2
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.21.3-rc5+rke2r2
+  - version: v1.21.3-rc6+rke2r2
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: &serverArgs-v1

--- a/data/data.json
+++ b/data/data.json
@@ -9751,7 +9751,7 @@
       "type": "array"
      }
     },
-    "version": "v1.21.3-rc5+rke2r2"
+    "version": "v1.21.3-rc6+rke2r2"
    }
   ]
  }


### PR DESCRIPTION
~Do not merge until CI for the v1.21.3-rc6+rke2r2 release tag completes.~
CI is done, ready for merge.