### PR TITLE
Update Calico chart version

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -97,7 +97,7 @@ releases:
         version: v3.13.300-build2021022306
       rke2-calico:
         repo: rancher-rke2-charts
-        version: v3.19.2-202
+        version: v3.19.2-203
       rke2-calico-crd:
         repo: rancher-rke2-charts
         version: v1.0.101

--- a/data/data.json
+++ b/data/data.json
@@ -9612,7 +9612,7 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "version": "v3.19.2-202"
+      "version": "v3.19.2-203"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
Calico chart version is updated to be aligned with the rke2 version

Linked issue: https://github.com/rancher/rke2/issues/1541

Signed-off-by: Manuel Buil <mbuil@suse.com>