### PR TITLE
[dev-v2.6] update version info for v1.18.20

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -8749,11 +8749,11 @@
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
-  "v1.18.19-rancher1-1": {
+  "v1.18.20-rancher1-1": {
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },
-  "v1.18.19-rancher1-2": {
+  "v1.18.20-rancher1-2": {
    "minRKEVersion": "1.1.3-rc0",
    "minRancherVersion": "2.4.5-rc0"
   },

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -460,13 +460,13 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.18.19-rancher1-1": {
+		"v1.18.20-rancher1-1": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",
 		},
 		// The Calico/Canal template in this version use functions that are only available in RKE v1.0.0 and up
 		// This version includes nodelocal dns only available in RKE v1.0.7 and up
-		"v1.18.19-rancher1-2": {
+		"v1.18.20-rancher1-2": {
 			MinRancherVersion: "2.4.5-rc0",
 			MinRKEVersion:     "1.1.3-rc0",
 		},


### PR DESCRIPTION
There's no v1.18.19 anymore. 