### PR TITLE
Rke2 bump

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -8,7 +8,7 @@ releases:
   - version: v1.20.10+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
-  - version: v1.21.4-rc1+rke2r2
+  - version: v1.21.4-rc2+rke2r2
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: &serverArgs-v1

--- a/data/data.json
+++ b/data/data.json
@@ -9846,7 +9846,7 @@
       "type": "array"
      }
     },
-    "version": "v1.21.4-rc1+rke2r2"
+    "version": "v1.21.4-rc2+rke2r2"
    }
   ]
  }


### PR DESCRIPTION
bump to v1.21.4-rc2+rke2r2
RC2 does two things over RC1
1. reverts an unwanted and unrelated change that was committed since 21.4+rke2r1 was released
2. properly bumps the k8s version that will display for the cluster