### PR TITLE
 rke2: cilium: Update the chart to 1.10.402

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -142,3 +142,6 @@ releases:
       harvester-csi-driver:
         repo: rancher-rke2-charts
         version: 0.1.300
+      rke2-cilium:
+        repo: rancher-rke2-charts
+        version: 1.10.402

--- a/data/data.json
+++ b/data/data.json
@@ -9785,7 +9785,7 @@
      },
      "rke2-cilium": {
       "repo": "rancher-rke2-charts",
-      "version": "1.9.808"
+      "version": "1.10.402"
      },
      "rke2-coredns": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
https://github.com/cilium/cilium/releases/tag/v1.10.4

Ref: rancher/rke2#1615

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>