### PR TITLE
Update rke2 calico chart version

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -94,7 +94,7 @@ releases:
         version: v3.13.300-build2021022306
       rke2-calico:
         repo: rancher-rke2-charts
-        version: v3.19.2-203
+        version: v3.19.2-204
       rke2-calico-crd:
         repo: rancher-rke2-charts
         version: v1.0.101

--- a/data/data.json
+++ b/data/data.json
@@ -9823,7 +9823,7 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "version": "v3.19.2-203"
+      "version": "v3.19.2-204"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",
@@ -9986,7 +9986,7 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "version": "v3.19.2-203"
+      "version": "v3.19.2-204"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
The new version fixes problems when deploying with cluster-cidr dual-stack

Signed-off-by: Manuel Buil <mbuil@suse.com>