### PR TITLE
[dev-2.5] K3s CVE-2021-41103

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -5,9 +5,9 @@ releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.4.5-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.19.15+k3s1
+  - version: v1.19.15+k3s2
     minChannelServerVersion: v2.5.0-rc1
     maxChannelServerVersion: v2.5.99
-  - version: v1.20.11+k3s1
+  - version: v1.20.11+k3s2
     minChannelServerVersion: v2.5.6-rc1
     maxChannelServerVersion: v2.5.99

--- a/data/data.json
+++ b/data/data.json
@@ -9215,12 +9215,12 @@
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.0-rc1",
-    "version": "v1.19.15+k3s1"
+    "version": "v1.19.15+k3s2"
    },
    {
     "maxChannelServerVersion": "v2.5.99",
     "minChannelServerVersion": "v2.5.6-rc1",
-    "version": "v1.20.11+k3s1"
+    "version": "v1.20.11+k3s2"
    }
   ]
  },


### PR DESCRIPTION
K3s updates for CVE-2021-41103
* https://github.com/k3s-io/k3s/issues/4157
* https://github.com/k3s-io/k3s/issues/4156
* https://github.com/k3s-io/k3s/issues/4155