### PR TITLE
Update chart versions for latest rke2 releases

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -225,6 +225,12 @@ releases:
       rke2-multus:
         repo: rancher-rke2-charts
         version: v3.7.1-build2021111906
+      harvester-cloud-provider:
+        repo: rancher-rke2-charts
+        version: 0.1.300
+      harvester-csi-driver:
+        repo: rancher-rke2-charts
+        version: 0.1.400
   - version: v1.22.4+rke2r1
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
@@ -234,6 +240,9 @@ releases:
       <<: *agentArgs-v1-21-5-rke2r2
     charts: &charts-v1-22-4-rke2r1
       <<: *charts-v1-21-7-rke2r1
-      rke2-canal:
+      rke2-calico:
         repo: rancher-rke2-charts
-        version: v3.20.1-build2021111904
+        version: v3.20.201
+      rke2-calico-crd:
+        repo: rancher-rke2-charts
+        version: v1.0.202

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -193,16 +193,16 @@ releases:
       rke2-ingress-nginx:
         repo: rancher-rke2-charts
         version: 4.0.305
-  - version: v1.21.7+rke2r1
+  - version: v1.21.7+rke2r2
     minChannelServerVersion: v2.6.1-alpha1
     maxChannelServerVersion: v2.6.99
-    serverArgs: &serverArgs-v1-21-7-rke2r1
+    serverArgs: &serverArgs-v1-21-7-rke2r2
       <<: *serverArgs-v1-21-5-rke2r2
       etcd-arg:
         type: array
-    agentArgs: &agentArgs-v1-21-7-rke2r1
+    agentArgs: &agentArgs-v1-21-7-rke2r2
       <<: *agentArgs-v1-21-5-rke2r2
-    charts: &charts-v1-21-7-rke2r1
+    charts: &charts-v1-21-7-rke2r2
       <<: *charts-v1-21-5-rke2r2
       rke2-canal:
         repo: rancher-rke2-charts
@@ -231,15 +231,15 @@ releases:
       harvester-csi-driver:
         repo: rancher-rke2-charts
         version: 0.1.400
-  - version: v1.22.4+rke2r1
+  - version: v1.22.4+rke2r2
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
-    serverArgs: &serverArgs-v1-22-4-rke2r1
-      <<: *serverArgs-v1-21-7-rke2r1
-    agentArgs: &agentArgs-v1-22-4-rke2r1
+    serverArgs: &serverArgs-v1-22-4-rke2r2
+      <<: *serverArgs-v1-21-7-rke2r2
+    agentArgs: &agentArgs-v1-22-4-rke2r2
       <<: *agentArgs-v1-21-5-rke2r2
-    charts: &charts-v1-22-4-rke2r1
-      <<: *charts-v1-21-7-rke2r1
+    charts: &charts-v1-22-4-rke2r2
+      <<: *charts-v1-21-7-rke2r2
       rke2-calico:
         repo: rancher-rke2-charts
         version: v3.20.201

--- a/data/data.json
+++ b/data/data.json
@@ -11830,7 +11830,7 @@
       "type": "array"
      }
     },
-    "version": "v1.21.7+rke2r1"
+    "version": "v1.21.7+rke2r2"
    },
    {
     "agentArgs": {
@@ -11996,7 +11996,7 @@
       "type": "array"
      }
     },
-    "version": "v1.22.4+rke2r1"
+    "version": "v1.22.4+rke2r2"
    }
   ]
  }

--- a/data/data.json
+++ b/data/data.json
@@ -11715,11 +11715,11 @@
     "charts": {
      "harvester-cloud-provider": {
       "repo": "rancher-rke2-charts",
-      "version": "0.1.200"
+      "version": "0.1.300"
      },
      "harvester-csi-driver": {
       "repo": "rancher-rke2-charts",
-      "version": "0.1.300"
+      "version": "0.1.400"
      },
      "rancher-vsphere-cpi": {
       "repo": "rancher-charts",
@@ -11881,11 +11881,11 @@
     "charts": {
      "harvester-cloud-provider": {
       "repo": "rancher-rke2-charts",
-      "version": "0.1.200"
+      "version": "0.1.300"
      },
      "harvester-csi-driver": {
       "repo": "rancher-rke2-charts",
-      "version": "0.1.300"
+      "version": "0.1.400"
      },
      "rancher-vsphere-cpi": {
       "repo": "rancher-charts",
@@ -11897,11 +11897,11 @@
      },
      "rke2-calico": {
       "repo": "rancher-rke2-charts",
-      "version": "v3.19.2-205"
+      "version": "v3.20.201"
      },
      "rke2-calico-crd": {
       "repo": "rancher-rke2-charts",
-      "version": "v1.0.101"
+      "version": "v1.0.202"
      },
      "rke2-canal": {
       "repo": "rancher-rke2-charts",


### PR DESCRIPTION
ssh shell was not working when attempting to install v1.22 through rancher due to an incorrect chart version for calico, and in fixing that I noticed there was a chart mismatch for both 1.21 and 1.22 in the harvester charts as well.