### PR TITLE
[dev-v2.6] Add dispatch script to trigger go generate on rke

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,23 @@ steps:
       event:
       - push
 
+  - name: dispatch
+    image: curlimages/curl:7.81.0
+    user: root
+    environment:
+      PAT_USERNAME:
+        from_secret: pat_username
+      PAT_TOKEN:
+        from_secret: github_token
+    commands:
+    - apk -U --no-cache add bash
+    - scripts/dispatch
+    when:
+      event:
+      - push
+    depends_on:
+    - upload
+
 volumes:
 - name: docker
   host:

--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+set -x
+
+REPO="https://api.github.com/repos/rancher/rke/actions/workflows/git-actions-go-generate.yml/dispatches"
+
+case $DRONE_BRANCH in
+  dev-v2.6|release-v2.6)
+    ACTION_TARGET_BRANCH="release/v1.3"
+    ;;
+  dev-v2.5|release-v2.5)
+    ACTION_TARGET_BRANCH="release/v1.2"
+    ;;
+  *)
+    echo "Not a valid branch, not dispatching event"
+    exit 0
+esac
+
+# send dispatch event to workflow
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.v3+json"  \
+        -H "Content-Type: application/json" $REPO \
+        --data '{"ref": "'"$ACTION_TARGET_BRANCH"'"}'


### PR DESCRIPTION
This adds a Drone action on push/upload to execute a script, that will trigger a GitHub Action workflow in RKE to run `go generate` which will update the uploaded `data.json` into RKE. (https://github.com/rancher/rke/actions/workflows/git-actions-go-generate.yml)