### PR TITLE
Add k8s v1.23 for k3s for rancher v2.6.4 + change default to 1.23.4 for RKE2 and k3s

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,6 +1,6 @@
 channels:
   - name: default
-    latest: v1.21.10+rke2r2
+    latest: v1.23.4+rke2r2
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -173,3 +173,8 @@ releases:
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2
+  - version: v1.23.4+k3s1
+    minChannelServerVersion: v2.6.4-alpha1
+    maxChannelServerVersion: v2.6.99
+    serverArgs: *serverArgs-v2
+    agentArgs: *agentArgs-v2

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
   - name: default
-    latest: v1.21.10+k3s1
+    latest: v1.23.4+k3s1
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -12786,6 +12786,155 @@
      }
     },
     "version": "v1.22.7+k3s1"
+   },
+   {
+    "agentArgs": {
+     "docker": {
+      "default": false,
+      "type": "boolean"
+     },
+     "flannel-conf": {
+      "type": "string"
+     },
+     "flannel-iface": {
+      "type": "string"
+     },
+     "kube-proxy-arg": {
+      "type": "array"
+     },
+     "kubelet-arg": {
+      "type": "array"
+     },
+     "pause-image": {
+      "type": "string"
+     },
+     "protect-kernel-defaults": {
+      "default": false,
+      "type": "boolean"
+     },
+     "resolv-conf": {
+      "type": "string"
+     },
+     "selinux": {
+      "default": false,
+      "type": "boolean"
+     },
+     "snapshotter": {
+      "type": "string"
+     },
+     "system-default-registry": {
+      "type": "string"
+     }
+    },
+    "maxChannelServerVersion": "v2.6.99",
+    "minChannelServerVersion": "v2.6.4-alpha1",
+    "serverArgs": {
+     "cluster-cidr": {
+      "type": "string"
+     },
+     "cluster-dns": {
+      "type": "string"
+     },
+     "cluster-domain": {
+      "type": "string"
+     },
+     "datastore-cafile": {
+      "type": "string"
+     },
+     "datastore-certfile": {
+      "type": "string"
+     },
+     "datastore-endpoint": {
+      "type": "string"
+     },
+     "datastore-keyfile": {
+      "type": "string"
+     },
+     "default-local-storage-path": {
+      "type": "string"
+     },
+     "disable": {
+      "options": [
+       "coredns",
+       "servicelb",
+       "traefik",
+       "local-storage",
+       "metrics-server"
+      ],
+      "type": "array"
+     },
+     "disable-apiserver": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-cloud-controller": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-controller-manager": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-etcd": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-kube-proxy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-network-policy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-scheduler": {
+      "default": false,
+      "type": "boolean"
+     },
+     "etcd-arg": {
+      "type": "array"
+     },
+     "etcd-expose-metrics": {
+      "default": false,
+      "type": "boolean"
+     },
+     "flannel-backend": {
+      "options": [
+       "none",
+       "vxlan",
+       "ipsec",
+       "host-gw",
+       "wireguard"
+      ],
+      "type": "enum"
+     },
+     "kube-apiserver-arg": {
+      "type": "array"
+     },
+     "kube-cloud-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-scheduler-arg": {
+      "type": "array"
+     },
+     "secrets-encryption": {
+      "default": false,
+      "type": "boolean"
+     },
+     "service-cidr": {
+      "type": "string"
+     },
+     "service-node-port-range": {
+      "type": "string"
+     },
+     "tls-san": {
+      "type": "array"
+     }
+    },
+    "version": "v1.23.4+k3s1"
    }
   ]
  },

--- a/data/data.json
+++ b/data/data.json
@@ -11015,7 +11015,7 @@
  "k3s": {
   "channels": [
    {
-    "latest": "v1.21.10+k3s1",
+    "latest": "v1.23.4+k3s1",
     "name": "default"
    }
   ],
@@ -12941,7 +12941,7 @@
  "rke2": {
   "channels": [
    {
-    "latest": "v1.21.10+rke2r2",
+    "latest": "v1.23.4+rke2r2",
     "name": "default"
    }
   ],


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/36336#issuecomment-1069626917

Additionally, changed the default to 1.23 from 1.21 which is planned to be the default in the 2.6.4 release.