### PR TITLE
Update default k8s for RKE1 to 1.22 from 1.23

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -10480,12 +10480,12 @@
   "2.6.1": "v1.21.x",
   "2.6.2": "v1.21.x",
   "2.6.3": "v1.21.x",
-  "2.6.4": "v1.23.x",
-  "default": "v1.23.x"
+  "2.6.4": "v1.22.x",
+  "default": "v1.22.x"
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.23.4-rancher1-1"
+  "default": "v1.22.7-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -33,9 +33,9 @@ func loadRancherDefaultK8sVersions() map[string]string {
 		"2.6.1": "v1.21.x",
 		"2.6.2": "v1.21.x",
 		"2.6.3": "v1.21.x",
-		"2.6.4": "v1.23.x",
+		"2.6.4": "v1.22.x",
 		// rancher will use default if its version is absent
-		"default": "v1.23.x",
+		"default": "v1.22.x",
 	}
 }
 
@@ -43,7 +43,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.23.4-rancher1-1",
+		"default": "v1.22.7-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
Updating the default k8s version to 1.22 from 1.23 for RKE as 1.23 is going to be experimental in 2.6.4 release.