### PR TITLE
Set minRancherServerVersion for 1.21.10 to rancher 2.6.3 in both rke2 and k3s

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -314,7 +314,7 @@ releases:
         repo: rancher-rke2-charts
         version: v3.20.3-build2022011406
   - version: v1.21.10+rke2r2
-    minChannelServerVersion: v2.6.4-alpha1
+    minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: &serverArgs-v1-21-10-rke2r2
       <<: *serverArgs-v1-21-9-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -149,7 +149,7 @@ releases:
       system-default-registry:
         type: string
   - version: v1.21.10+k3s1
-    minChannelServerVersion: v2.6.0-alpha1
+    minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2

--- a/data/data.json
+++ b/data/data.json
@@ -12179,7 +12179,7 @@
      }
     },
     "maxChannelServerVersion": "v2.6.99",
-    "minChannelServerVersion": "v2.6.0-alpha1",
+    "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "cluster-cidr": {
       "type": "string"
@@ -14876,7 +14876,7 @@
      }
     },
     "maxChannelServerVersion": "v2.6.99",
-    "minChannelServerVersion": "v2.6.4-alpha1",
+    "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "audit-policy-file": {
       "type": "string"


### PR DESCRIPTION
Based on https://github.com/rancher/kontainer-driver-metadata/pull/847#discussion_r835264148