### PR TITLE
[release-rke-v1.3.7] Skip checks for changes in released versions

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -21,5 +21,5 @@ if [ -n "$DIRTY" ]; then
     exit 1
 fi
 
-echo Checking if released versions are not changed
-python3 check-kdm-data.py release-v2.5 release-v2.6
+echo Skip checks for changes in released versions for special branch release-rke-v1.3.7
+# python3 check-kdm-data.py release-v2.5 release-v2.6


### PR DESCRIPTION
**Problem**
----- 
We need to pin KDM data to the data released for RKE1 `v1.3.7` to address issue https://github.com/rancher/rancher/issues/37088 (Rancher's local data for `v2.6.3-patch3` needs to be consistent with vendored RKE1 version, v1.3.7). This causes tests to fail because they validate the versions in release branch haven't changed or removed. 

**Solution** 
------
There are new versions present in `release-v2.6` which don't need to exist in `release-rke-v1.3.7` so skipping tests for this branch. 