### PR TITLE
update default k8s to v1.21.x

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,6 +1,6 @@
 channels:
   - name: default
-    latest: v1.22.7+rke2r2
+    latest: v1.21.10+rke2r2
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
   - name: default
-    latest: v1.22.7+k3s1
+    latest: v1.21.10+k3s1
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -10482,12 +10482,13 @@
   "2.6.3": "v1.21.x",
   "2.6.3-patch1": "v1.21.x",
   "2.6.3-patch2": "v1.21.x",
-  "2.6.4": "v1.22.x",
+  "2.6.3-patch3": "v1.21.x",
+  "2.6.4": "v1.21.x",
   "default": "v1.22.x"
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.22.7-rancher1-1"
+  "default": "v1.21.10-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [
@@ -11106,7 +11107,7 @@
  "k3s": {
   "channels": [
    {
-    "latest": "v1.22.7+k3s1",
+    "latest": "v1.21.10+k3s1",
     "name": "default"
    }
   ],
@@ -13032,7 +13033,7 @@
  "rke2": {
   "channels": [
    {
-    "latest": "v1.22.7+rke2r2",
+    "latest": "v1.21.10+rke2r2",
     "name": "default"
    }
   ],

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -35,7 +35,8 @@ func loadRancherDefaultK8sVersions() map[string]string {
 		"2.6.3":        "v1.21.x",
 		"2.6.3-patch1": "v1.21.x",
 		"2.6.3-patch2": "v1.21.x",
-		"2.6.4":        "v1.22.x",
+		"2.6.3-patch3": "v1.21.x",
+		"2.6.4":        "v1.21.x",
 		// rancher will use default if its version is absent
 		"default": "v1.22.x",
 	}
@@ -45,7 +46,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.22.7-rancher1-1",
+		"default": "v1.21.10-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37162

We'll announce in forums and release notes with upstream recommendations. 

**RKE1 standalone**: 
--- 
Existing clusters provisioned using RKE <= v1.3.8 and k8s v1.22.x will need to add `kubernetes_version` in cluster.yml before running `rke up` with RKE v1.3.9. This ensures provisioned clusters don't auto-downgrade. New clusters created with RKE v1.3.9 will be created with k8s v1.21.x by default. 

**Rancher-RKE1/RKE2/k3s**
--- 
Existing clusters running v1.22.x won't downgrade, latest v1.22.x will show up as experimental in Edit Cluster if a newer version is available (until a fixed version is released). When creating new clusters, latest available v1.22.x will show as experimental. 
