### PR TITLE
add the appDefault section for rke2 and k3s

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1,6 +1,11 @@
 channels:
   - name: default
     latest: v1.22.8+rke2r1
+appDefaults:
+  - appName: rancher
+    defaults:
+      - appVersion: '> 2.6.0-0 < 2.6.99-0'
+        defaultVersion: '1.22.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,11 @@
 channels:
   - name: default
     latest: v1.22.8+k3s1
+appDefaults:
+  - appName: rancher
+    defaults:
+      - appVersion: '> 2.6.0-0 < 2.6.99-0'
+        defaultVersion: '1.22.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -11403,6 +11403,17 @@
   }
  },
  "k3s": {
+  "appDefaults": [
+   {
+    "appName": "rancher",
+    "defaults": [
+     {
+      "appVersion": "\u003e 2.6.0-0 \u003c 2.6.99-0",
+      "defaultVersion": "1.22.x"
+     }
+    ]
+   }
+  ],
   "channels": [
    {
     "latest": "v1.22.8+k3s1",
@@ -13776,6 +13787,17 @@
   ]
  },
  "rke2": {
+  "appDefaults": [
+   {
+    "appName": "rancher",
+    "defaults": [
+     {
+      "appVersion": "\u003e 2.6.0-0 \u003c 2.6.99-0",
+      "defaultVersion": "1.22.x"
+     }
+    ]
+   }
+  ],
   "channels": [
    {
     "latest": "v1.22.8+rke2r1",


### PR DESCRIPTION
 
This PR is to add the `appDefault` section for rke2 and k3s. 

Please check the following issue for usage:
-  https://github.com/rancher/rancher/issues/36827

and the following PRs for implementation details: 
- https://github.com/rancher/channelserver/pull/17
- https://github.com/rancher/rancher/pull/37163