### PR TITLE
[dev-2.6] bump the default k8s for RKE1 to 1.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /trash.lock
 /.idea
 .dapper
+.DS_Store

--- a/data/data.json
+++ b/data/data.json
@@ -10977,11 +10977,12 @@
   "2.6.3-patch1": "v1.21.x",
   "2.6.3-patch2": "v1.21.x",
   "2.6.4": "v1.22.x",
-  "default": "v1.22.x"
+  "2.6.5": "v1.23.x",
+  "default": "v1.23.x"
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.22.9-rancher1-1"
+  "default": "v1.23.5-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -36,8 +36,9 @@ func loadRancherDefaultK8sVersions() map[string]string {
 		"2.6.3-patch1": "v1.21.x",
 		"2.6.3-patch2": "v1.21.x",
 		"2.6.4":        "v1.22.x",
+		"2.6.5":        "v1.23.x",
 		// rancher will use default if its version is absent
-		"default": "v1.22.x",
+		"default": "v1.23.x",
 	}
 }
 
@@ -45,7 +46,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.22.9-rancher1-1",
+		"default": "v1.23.5-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37432

This PR is to bump the default k8s for RKE1 to 1.23 for Rancher v2.6.5,
it also includes a small fix for ignoring the annoying DS_Store file in macOS. 