### PR TITLE
[Rancher v2.6.5] Bump the default rke, rke2, and k3s to 1.23 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /trash.lock
 /.idea
 .dapper
+.DS_Store

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -4,8 +4,10 @@ channels:
 appDefaults:
   - appName: rancher
     defaults:
-      - appVersion: '> 2.6.0-0 < 2.6.99-0'
+      - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
+      - appVersion: '>= 2.6.5-0 < 2.6.99-0'
+        defaultVersion: '1.23.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -4,8 +4,10 @@ channels:
 appDefaults:
   - appName: rancher
     defaults:
-      - appVersion: '> 2.6.0-0 < 2.6.99-0'
+      - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
+      - appVersion: '>= 2.6.5-0 < 2.6.99-0'
+        defaultVersion: '1.23.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -10954,11 +10954,12 @@
   "2.6.3-patch1": "v1.21.x",
   "2.6.3-patch2": "v1.21.x",
   "2.6.4": "v1.22.x",
-  "default": "v1.22.x"
+  "2.6.5": "v1.23.x",
+  "default": "v1.23.x"
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.22.9-rancher1-1"
+  "default": "v1.23.6-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [
@@ -11651,8 +11652,12 @@
     "appName": "rancher",
     "defaults": [
      {
-      "appVersion": "\u003e 2.6.0-0 \u003c 2.6.99-0",
+      "appVersion": "\u003e= 2.6.0-0 \u003c 2.6.5-0",
       "defaultVersion": "1.22.x"
+     },
+     {
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.99-0",
+      "defaultVersion": "1.23.x"
      }
     ]
    }
@@ -14035,8 +14040,12 @@
     "appName": "rancher",
     "defaults": [
      {
-      "appVersion": "\u003e 2.6.0-0 \u003c 2.6.99-0",
+      "appVersion": "\u003e= 2.6.0-0 \u003c 2.6.5-0",
       "defaultVersion": "1.22.x"
+     },
+     {
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.99-0",
+      "defaultVersion": "1.23.x"
      }
     ]
    }

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -36,8 +36,9 @@ func loadRancherDefaultK8sVersions() map[string]string {
 		"2.6.3-patch1": "v1.21.x",
 		"2.6.3-patch2": "v1.21.x",
 		"2.6.4":        "v1.22.x",
+		"2.6.5":        "v1.23.x",
 		// rancher will use default if its version is absent
-		"default": "v1.22.x",
+		"default": "v1.23.x",
 	}
 }
 
@@ -45,7 +46,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.22.9-rancher1-1",
+		"default": "v1.23.6-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37432

This PR is to bump the default rke, rke2, and k3s to 1.23 for Rancher v2.6.5,
it also includes a small fix for ignoring the annoying DS_Store file in macOS. 