### PR TITLE
remove v1.22.8-rancher1-1 version constraints

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -10896,10 +10896,6 @@
    "minRKEVersion": "1.3.3-rc0",
    "minRancherVersion": "2.6.3-patch0"
   },
-  "v1.22.8-rancher1-1": {
-   "minRKEVersion": "1.3.3-rc0",
-   "minRancherVersion": "2.6.3-patch0"
-  },
   "v1.22.9-rancher1-1": {
    "minRKEVersion": "1.3.3-rc0",
    "minRancherVersion": "2.6.3-patch0"

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -629,10 +629,6 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MinRancherVersion: "2.6.3-patch0",
 			MinRKEVersion:     "1.3.3-rc0",
 		},
-		"v1.22.8-rancher1-1": {
-			MinRancherVersion: "2.6.3-patch0",
-			MinRKEVersion:     "1.3.3-rc0",
-		},
 		"v1.22.9-rancher1-1": {
 			MinRancherVersion: "2.6.3-patch0",
 			MinRKEVersion:     "1.3.3-rc0",


### PR DESCRIPTION
releasing v1.22.9 images so don't need v1.22.8 info in kdm