### PR TITLE
[dev-v2.6] Use correct inputs to dispatch

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -17,7 +17,6 @@ case $DRONE_BRANCH in
 esac
 
 echo "DRONE_BRANCH: $DRONE_BRANCH"
-echo "DRONE_COMMIT_LINK: $DRONE_COMMIT_LINK"
 echo "DRONE_COMMIT_AUTHOR: $DRONE_COMMIT_AUTHOR"
 
 echo "Dispatching to branch ${ACTION_TARGET_BRANCH}"
@@ -26,4 +25,4 @@ echo "Dispatching to branch ${ACTION_TARGET_BRANCH}"
 curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
         -H "Accept: application/vnd.github.v3+json"  \
         -H "Content-Type: application/json" $REPO \
-        --data '{"ref": "'"$ACTION_TARGET_BRANCH"'","inputs":{"INPUT_SOURCE_URL":"'"$DRONE_COMMIT_LINK"'","INPUT_SOURCE_AUTHOR":"'"$DRONE_COMMIT_AUTHOR"'"}}'
+        --data '{"ref": "'"$ACTION_TARGET_BRANCH"'","inputs":{"source_author":"'"$DRONE_COMMIT_AUTHOR"'"}}'


### PR DESCRIPTION
I messed up the inputs;

```
{
  "message": "Unexpected inputs provided: [\"INPUT_SOURCE_URL\", \"INPUT_SOURCE_AUTHOR\"]",
  "documentation_url": "https://docs.github.com/rest/reference/actions#create-a-workflow-dispatch-event"
}
```

Also the variable `DRONE_COMMIT_LINK` was pointing to a compare link which does not link to the PR because it is a separate event that kicks off `drone-publish` which has no info on the pull request that caused the merge/push.

```
+ echo 'DRONE_COMMIT_LINK: https://github.com/rancher/kontainer-driver-metadata/compare/f9d951251b01...61b41882360b'
```