### PR TITLE
[dev-v2.6] Depend upload step on validate

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,6 +29,9 @@ steps:
     when:
       event:
       - push
+    depends_on:
+    - validate
+
 
   - name: dispatch
     image: curlimages/curl:7.81.0


### PR DESCRIPTION
Was watching a build and saw that we upload without waiting for `validate`, this adds a dependency on `validate` for `upload`

<img width="384" alt="Screenshot 2022-05-05 at 08 07 59" src="https://user-images.githubusercontent.com/2620179/166878704-6fd4fc4f-5049-4abd-b65a-b8fc49e2d925.png">
