### PR TITLE
Rancher 2.6.5 to support k8s 1.22+ only for provisioning

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -20,7 +20,7 @@ releases:
     maxChannelServerVersion: v2.6.99
   - version: v1.21.4+k3s1
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: &serverArgs-v1
       tls-san:
         type: array
@@ -121,22 +121,22 @@ releases:
         type: string
   - version: v1.21.5+k3s1
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v1
     agentArgs: *agentArgs-v1
   - version: v1.21.5+k3s2
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v1
     agentArgs: *agentArgs-v1
   - version: v1.21.6+k3s1
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v1
     agentArgs: *agentArgs-v1
   - version: v1.21.7+k3s1
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: &serverArgs-v2
       <<: *serverArgs-v1
       etcd-arg:
@@ -144,12 +144,12 @@ releases:
     agentArgs: *agentArgs-v1
   - version: v1.21.8+k3s2
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v1
   - version: v1.21.9+k3s1
     minChannelServerVersion: v2.6.0-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: &agentArgs-v2
       <<: *agentArgs-v1
@@ -157,13 +157,13 @@ releases:
         type: string
   - version: v1.21.10+k3s1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2
   # v1.21.11+k3s1 was never released through KDM
   - version: v1.21.12+k3s1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.6.99
+    maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2
   - version: v1.22.4+k3s1

--- a/data/data.json
+++ b/data/data.json
@@ -11720,7 +11720,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -11863,7 +11863,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12006,7 +12006,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12149,7 +12149,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12292,7 +12292,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12438,7 +12438,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12587,7 +12587,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12736,7 +12736,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -12885,7 +12885,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.6.99",
+    "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "cluster-cidr": {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37547 (for k3s)

Per https://github.com/rancher/kontainer-driver-metadata/pull/897 the same limit was applied to RKE2, however it makes sense to do the same for k3s.