### PR TITLE
Make the default rke2/k3s versions in v2.6-head the same as in 2.6.5-rc

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -6,7 +6,7 @@ appDefaults:
     defaults:
       - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
-      - appVersion: '>= 2.6.5-0 < 2.6.99-0'
+      - appVersion: '>= 2.6.5-0 < 2.6.100-0'
         defaultVersion: '1.23.x'
 releases:
   - version: v1.19.16+rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -6,7 +6,7 @@ appDefaults:
     defaults:
       - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
-      - appVersion: '>= 2.6.5-0 < 2.6.99-0'
+      - appVersion: '>= 2.6.5-0 < 2.6.100-0'
         defaultVersion: '1.23.x'
 releases:
   - version: v1.18.20+k3s1

--- a/data/data.json
+++ b/data/data.json
@@ -11656,7 +11656,7 @@
       "defaultVersion": "1.22.x"
      },
      {
-      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.99-0",
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.100-0",
       "defaultVersion": "1.23.x"
      }
     ]
@@ -14044,7 +14044,7 @@
       "defaultVersion": "1.22.x"
      },
      {
-      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.99-0",
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.100-0",
       "defaultVersion": "1.23.x"
      }
     ]


### PR DESCRIPTION
issue https://github.com/rancher/rancher/issues/37547

Because rancher treats v2.6-head as 2.6.99 internally when determining the default rke2/k3s version, the upper bound needs to be `2.6.100-0` to make the default rke2/k3s versions in v2.6-head the same as in 2.6.5-rc.


Test:
In rancher 2.6-head, I change the KDM to my branch and rancher show 1.23.x as the default rke2/k3s version. 