### PR TITLE
[2.6] Fix kube-dns image in May patch.

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -10279,7 +10279,7 @@
    "nginxProxy": "rancher/rke-tools:v0.1.80",
    "certDownloader": "rancher/rke-tools:v0.1.80",
    "kubernetesServicesSidecar": "rancher/rke-tools:v0.1.80",
-   "kubedns": "rancher/mirrored-k8s-dns-node-cache:1.21.1",
+   "kubedns": "rancher/mirrored-k8s-dns-kube-dns:1.21.1",
    "dnsmasq": "rancher/mirrored-k8s-dns-dnsmasq-nanny:1.21.1",
    "kubednsSidecar": "rancher/mirrored-k8s-dns-sidecar:1.21.1",
    "kubednsAutoscaler": "rancher/mirrored-cluster-proportional-autoscaler:1.8.5",

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -7546,7 +7546,7 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			NginxProxy:                "rancher/rke-tools:v0.1.80",
 			CertDownloader:            "rancher/rke-tools:v0.1.80",
 			KubernetesServicesSidecar: "rancher/rke-tools:v0.1.80",
-			KubeDNS:                   "rancher/mirrored-k8s-dns-node-cache:1.21.1",
+			KubeDNS:                   "rancher/mirrored-k8s-dns-kube-dns:1.21.1",
 			DNSmasq:                   "rancher/mirrored-k8s-dns-dnsmasq-nanny:1.21.1",
 			KubeDNSSidecar:            "rancher/mirrored-k8s-dns-sidecar:1.21.1",
 			KubeDNSAutoscaler:         "rancher/mirrored-cluster-proportional-autoscaler:1.8.5",


### PR DESCRIPTION
Changed the kube-dns image in `1.23.7` from `rancher/mirrored-k8s-dns-node-cache` to `rancher/mirrored-k8s-dns-kube-dns`

Linked issue:
https://github.com/rancher/rancher/issues/37890