### PR TITLE
add v1.24.2-rancher1-1 by replacing v1.24.1-rancher1-1

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -10464,7 +10464,7 @@
    "aciGbpServerContainer": "noiro/gbp-server:5.1.1.0.1ae238a",
    "aciOpflexServerContainer": "noiro/opflex-server:5.1.1.0.1ae238a"
   },
-  "v1.24.1-rancher1-1": {
+  "v1.24.2-rancher1-1": {
    "etcd": "rancher/mirrored-coreos-etcd:v3.5.4",
    "alpine": "rancher/rke-tools:v0.1.83",
    "nginxProxy": "rancher/rke-tools:v0.1.83",
@@ -10477,7 +10477,7 @@
    "coredns": "rancher/mirrored-coredns-coredns:1.9.3",
    "corednsAutoscaler": "rancher/mirrored-cluster-proportional-autoscaler:1.8.5",
    "nodelocal": "rancher/mirrored-k8s-dns-node-cache:1.21.1",
-   "kubernetes": "rancher/hyperkube:v1.24.1-rancher1",
+   "kubernetes": "rancher/hyperkube:v1.24.2-rancher1",
    "flannel": "rancher/mirrored-coreos-flannel:v0.15.1",
    "flannelCni": "rancher/flannel-cni:v0.3.0-rancher6",
    "calicoNode": "rancher/mirrored-calico-node:v3.22.0",

--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -7670,9 +7670,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			WindowsPodInfraContainer:  "rancher/mirrored-pause:3.6",
 			Nodelocal:                 "rancher/mirrored-k8s-dns-node-cache:1.21.1",
 		},
-		"v1.24.1-rancher1-1": {
+		"v1.24.2-rancher1-1": {
 			Etcd:                      "rancher/mirrored-coreos-etcd:v3.5.4",
-			Kubernetes:                "rancher/hyperkube:v1.24.1-rancher1",
+			Kubernetes:                "rancher/hyperkube:v1.24.2-rancher1",
 			Alpine:                    "rancher/rke-tools:v0.1.83",
 			NginxProxy:                "rancher/rke-tools:v0.1.83",
 			CertDownloader:            "rancher/rke-tools:v0.1.83",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37711

We will release the latest 1.24 release, so we replace  `v1.24.1-rancher1-1` with `v1.24.2-rancher1-1` in the PR. 