### PR TITLE
Enable encryption key rotation k3s

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -176,6 +176,8 @@ releases:
     maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2
+    featureVersions: &featureVersions-v1
+      encryption-key-rotation: "2.0.0"
   - version: v1.22.4+k3s1
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
@@ -216,6 +218,7 @@ releases:
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
+    featureVersions: *featureVersions-v1
   - version: v1.23.4+k3s1
     minChannelServerVersion: v2.6.4-alpha1
     maxChannelServerVersion: v2.6.99
@@ -238,3 +241,4 @@ releases:
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
+    featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -13733,6 +13733,9 @@
       "type": "string"
      }
     },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
     "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
@@ -14773,6 +14776,9 @@
       "type": "string"
      }
     },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
@@ -15374,6 +15380,9 @@
      "system-default-registry": {
       "type": "string"
      }
+    },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.4-alpha1",


### PR DESCRIPTION
Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/35436
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
# Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Encryption key rotation is locked behind feature gates in KDM, so it currently will instantly fail in rancher if it is requested for a version that does not support it. 

# Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Allow encryption key rotation for known working versions.
 
# Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
## Engineering Testing

I've tested each of these versions manually and using validation tests.