### PR TITLE
Enable encryption key rotation rke2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -422,6 +422,8 @@ releases:
       rke2-coredns:
         repo: rancher-rke2-charts
         version: 1.19.400
+    featureVersions: &featureVersions-v1-21-14-rke2r1
+      encryption-key-rotation: "2.0.0"
   - version: v1.22.4+rke2r2
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
@@ -589,6 +591,8 @@ releases:
       rke2-multus:
         repo: rancher-rke2-charts
         version: v3.8-build2021110403
+    featureVersions: &featureVersions-v1-22-11-rke2r1
+      <<: *featureVersions-v1-21-14-rke2r1
   - version: v1.23.4+rke2r2
     minChannelServerVersion: v2.6.4-alpha1
     maxChannelServerVersion: v2.6.99
@@ -702,3 +706,5 @@ releases:
       rke2-multus:
         repo: rancher-rke2-charts
         version: v3.8-build2021110403
+    featureVersions: &featureVersions-v1-23-8-rke2r1
+      <<: *featureVersions-v1-21-14-rke2r1

--- a/data/data.json
+++ b/data/data.json
@@ -18327,6 +18327,9 @@
       "version": "v3.7.1-build2021111906"
      }
     },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
     "maxChannelServerVersion": "v2.6.4",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
@@ -20282,6 +20285,9 @@
       "version": "v3.8-build2021110403"
      }
     },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
@@ -21507,6 +21513,9 @@
       "repo": "rancher-rke2-charts",
       "version": "v3.8-build2021110403"
      }
+    },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.4-alpha1",


### PR DESCRIPTION
Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/35436
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
# Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Encryption key rotation is locked behind feature gates in KDM, so it currently will instantly fail in rancher if it is requested for a version that does not support it. 

# Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Allow encryption key rotation for known working versions.
 
# Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
## Engineering Testing

I've tested enabling encryption key rotation using a fork of KDM with similar changes, for the previous rcs compiled from source.