### PR TITLE
Update channels.yaml for 2022-06 k3s2 releases 

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,6 @@
 channels:
   - name: default
-    latest: v1.22.11+k3s1
+    latest: v1.22.11+k3s2
 appDefaults:
   - appName: rancher
     defaults:
@@ -210,7 +210,8 @@ releases:
       egress-selector-mode:
         type: string
     agentArgs: *agentArgs-v2
-  - version: v1.22.11+k3s1
+  # v1.22.11+k3s1 was never released through KDM
+  - version: v1.22.11+k3s2
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
@@ -231,7 +232,8 @@ releases:
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
-  - version: v1.23.8+k3s1
+  #  v1.23.8+k3s1 was never released through KDM
+  - version: v1.23.8+k3s2
     minChannelServerVersion: v2.6.4-alpha1
     maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3

--- a/data/data.json
+++ b/data/data.json
@@ -12214,7 +12214,7 @@
   ],
   "channels": [
    {
-    "latest": "v1.22.11+k3s1",
+    "latest": "v1.22.11+k3s2",
     "name": "default"
    }
   ],
@@ -14884,7 +14884,7 @@
       "type": "array"
      }
     },
-    "version": "v1.22.11+k3s1"
+    "version": "v1.22.11+k3s2"
    },
    {
     "agentArgs": {
@@ -15486,7 +15486,7 @@
       "type": "array"
      }
     },
-    "version": "v1.23.8+k3s1"
+    "version": "v1.23.8+k3s2"
    }
   ]
  },


### PR DESCRIPTION
These supersede the k3s1 releases, which never made it to the release-v2.6 branch.