### PR TITLE
bump the default version of RKE2/K3s to 1.24 for rancher 2.6.7

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -6,8 +6,10 @@ appDefaults:
     defaults:
       - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
-      - appVersion: '>= 2.6.5-0 < 2.6.100-0'
+      - appVersion: '>= 2.6.5-0 < 2.6.7-0'
         defaultVersion: '1.23.x'
+      - appVersion: '>= 2.6.7-0 < 2.6.100-0'
+        defaultVersion: '1.24.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -6,8 +6,10 @@ appDefaults:
     defaults:
       - appVersion: '>= 2.6.0-0 < 2.6.5-0'
         defaultVersion: '1.22.x'
-      - appVersion: '>= 2.6.5-0 < 2.6.100-0'
+      - appVersion: '>= 2.6.5-0 < 2.6.7-0'
         defaultVersion: '1.23.x'
+      - appVersion: '>= 2.6.7-0 < 2.6.100-0'
+        defaultVersion: '1.24.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -12214,8 +12214,12 @@
       "defaultVersion": "1.22.x"
      },
      {
-      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.100-0",
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.7-0",
       "defaultVersion": "1.23.x"
+     },
+     {
+      "appVersion": "\u003e= 2.6.7-0 \u003c 2.6.100-0",
+      "defaultVersion": "1.24.x"
      }
     ]
    }
@@ -15672,8 +15676,12 @@
       "defaultVersion": "1.22.x"
      },
      {
-      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.100-0",
+      "appVersion": "\u003e= 2.6.5-0 \u003c 2.6.7-0",
       "defaultVersion": "1.23.x"
+     },
+     {
+      "appVersion": "\u003e= 2.6.7-0 \u003c 2.6.100-0",
+      "defaultVersion": "1.24.x"
      }
     ]
    }


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/38348

bump the default version of RKE2/K3s to 1.24 for rancher 2.6.7
 