### PR TITLE
bump rke default version to v1.24.2-rancher1-1

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -11475,7 +11475,7 @@
  },
  "RKEDefaultK8sVersions": {
   "0.3": "v1.16.3-rancher1-1",
-  "default": "v1.23.8-rancher1-1"
+  "default": "v1.24.2-rancher1-1"
  },
  "K8sVersionDockerInfo": {
   "1.10": [

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -46,7 +46,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.23.8-rancher1-1",
+		"default": "v1.24.2-rancher1-1",
 	}
 }
 
@@ -609,7 +609,7 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.20.15-rancher2-1": {
 			MinRancherVersion: "2.5.11-rc0",
 			MinRKEVersion:     "1.2.14-rc0",
-		},		
+		},
 		"v1.21": {
 			MinRancherVersion: "2.6.0-rc0",
 			MinRKEVersion:     "1.3.0-rc0",


### PR DESCRIPTION
issue: https://github.com/rancher/rke/issues/2989

bump rke default version to v1.24.2-rancher1-1

Dev Test:
tried on the dev environment and see the following:
```
./rke config -l
WARN[0000] This is not an officially supported version (dev) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases 
v1.24.2-rancher1-1
```