### PR TITLE
add rancher version info for v1.22.11

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -11388,6 +11388,10 @@
    "minRKEVersion": "1.3.3-rc0",
    "minRancherVersion": "2.6.3-patch0"
   },
+  "v1.22.11-rancher1-1": {
+   "minRKEVersion": "1.3.3-rc0",
+   "minRancherVersion": "2.6.3-patch0"
+  },
   "v1.22.4-rancher1-1": {
    "minRKEVersion": "1.3.3-rc0",
    "minRancherVersion": "2.6.3-patch0"

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -656,6 +656,10 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 			MinRancherVersion: "2.6.3-patch0",
 			MinRKEVersion:     "1.3.3-rc0",
 		},
+		"v1.22.11-rancher1-1": {
+			MinRancherVersion: "2.6.3-patch0",
+			MinRKEVersion:     "1.3.3-rc0",
+		},
 		"v1.8.10-rancher1-1": {
 			DeprecateRKEVersion:     "0.2.2",
 			DeprecateRancherVersion: "2.2",


### PR DESCRIPTION
Found missing during v2.6 kdm release https://github.com/rancher/kontainer-driver-metadata/pull/950 