### PR TITLE
Skipping release versions check for release-rke-v1.3.13

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,5 +24,5 @@ if [ -n "$DIRTY" ]; then
     exit 1
 fi
 
-echo Checking if released versions are not changed
-python3 check-kdm-data.py release-v2.5 release-v2.6
+echo Skipping release versions check, out of band versions were released after RKE v1.3.13
+# python3 check-kdm-data.py release-v2.5 release-v2.6


### PR DESCRIPTION
**Problem**
We validate if already released versions aren't missing or haven't changed after the release went out. Since this is a special branch created to pin down to a previous commit after the release-v2.6 was updated, the validation is failing and new data isn't pushed. 

https://drone-publish.rancher.io/rancher/kontainer-driver-metadata/704 
`Configuration for released Rancher k8s version v1.19.16-rancher1-6 is missing` 

https://github.com/rancher/rancher/pull/38133

**Solution**
Skipping this test for release-rke-v1.3.13 branch. We know these versions are supposed to be out of band for Rancher v2.6.6 release. 