### PR TITLE
[WIP] A more reliable way to format yaml for go generate

### DIFF
--- a/driver_data/k3s/app_defaults.yaml
+++ b/driver_data/k3s/app_defaults.yaml
@@ -1,0 +1,9 @@
+appDefaults:
+  - appName: rancher
+    defaults:
+      - appVersion: '>= 2.6.0-0 < 2.6.5-0'
+        defaultVersion: '1.22.x'
+      - appVersion: '>= 2.6.5-0 < 2.6.7-0'
+        defaultVersion: '1.23.x'
+      - appVersion: '>= 2.6.7-0 < 2.7.100-0'
+        defaultVersion: '1.24.x'

--- a/driver_data/k3s/channels.yaml
+++ b/driver_data/k3s/channels.yaml
@@ -1,0 +1,3 @@
+channels:
+  - name: default
+    latest: v1.22.15+k3s1

--- a/driver_data/k3s/releases/v1.18.20+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.18.20+k3s1.yaml
@@ -1,0 +1,3 @@
+version: v1.18.20+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.99

--- a/driver_data/k3s/releases/v1.19.16+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.19.16+k3s1.yaml
@@ -1,0 +1,3 @@
+version: v1.19.16+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.99

--- a/driver_data/k3s/releases/v1.20.15+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.20.15+k3s1.yaml
@@ -1,0 +1,3 @@
+version: v1.20.15+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.99

--- a/driver_data/k3s/releases/v1.21.10+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.10+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.21.10+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.12+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.12+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.21.12+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.13+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.13+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.21.13+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.14+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.14+k3s1.yaml
@@ -1,0 +1,107 @@
+version: v1.21.14+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.4+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.4+k3s1.yaml
@@ -1,0 +1,101 @@
+version: v1.21.4+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.5+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.5+k3s1.yaml
@@ -1,0 +1,101 @@
+version: v1.21.5+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+serverArgs:
+  tls-san:
+    type: array
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  flannel-backend:
+    type: enum
+    options:
+      - none
+      - vxlan
+      - ipsec
+      - host-gw
+      - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+      - coredns
+      - servicelb
+      - traefik
+      - local-storage
+      - metrics-server
+  disable-scheduler:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  secrets-encryption:
+    type: boolean
+    default: false
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  selinux:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string

--- a/driver_data/k3s/releases/v1.21.5+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.21.5+k3s2.yaml
@@ -1,0 +1,101 @@
+version: v1.21.5+k3s2
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+serverArgs:
+  tls-san:
+    type: array
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  flannel-backend:
+    type: enum
+    options:
+      - none
+      - vxlan
+      - ipsec
+      - host-gw
+      - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+      - coredns
+      - servicelb
+      - traefik
+      - local-storage
+      - metrics-server
+  disable-scheduler:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  secrets-encryption:
+    type: boolean
+    default: false
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  selinux:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string

--- a/driver_data/k3s/releases/v1.21.6+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.6+k3s1.yaml
@@ -1,0 +1,101 @@
+version: v1.21.6+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.7+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.7+k3s1.yaml
@@ -1,0 +1,103 @@
+version: v1.21.7+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.8+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.21.8+k3s2.yaml
@@ -1,0 +1,103 @@
+version: v1.21.8+k3s2
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs: &serverArgs-v2
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.21.9+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.21.9+k3s1.yaml
@@ -1,0 +1,106 @@
+version: v1.21.9+k3s1
+minChannelServerVersion: v2.6.0-alpha1
+maxChannelServerVersion: v2.6.4
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array
+ 

--- a/driver_data/k3s/releases/v1.22.10+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.10+k3s1.yaml
@@ -1,0 +1,107 @@
+version: v1.22.10+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  pause-image:
+    type: string
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  snapshotter:
+    type: string
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.11+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.22.11+k3s2.yaml
@@ -1,0 +1,112 @@
+version: v1.22.11+k3s2
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs: v2
+featureVersions: v1
+serverArgs: v3
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.13+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.13+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.22.13+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.15+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.15+k3s1.yaml
@@ -1,6 +1,6 @@
 version: v1.22.15+k3s1
 minChannelServerVersion: v2.6.3-alpha1
-maxChannelServerVersion: v2.7.99
+maxChannelServerVersion: v2.6.99
 agentArgs:
   docker:
     type: boolean

--- a/driver_data/k3s/releases/v1.22.15+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.15+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.22.15+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.4+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.4+k3s1.yaml
@@ -1,0 +1,103 @@
+version: v1.22.4+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.5+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.22.5+k3s2.yaml
@@ -1,0 +1,103 @@
+version: v1.22.5+k3s2
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.6+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.6+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.22.6+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.7+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.7+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.22.7+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.22.9+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.22.9+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.22.9+k3s1
+minChannelServerVersion: v2.6.3-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.23.10+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.10+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.23.10+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.23.12+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.12+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.23.12+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.23.13+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.13+k3s1.yaml
@@ -1,6 +1,6 @@
-version: v1.22.13+k3s1
-minChannelServerVersion: v2.6.3-alpha1
-maxChannelServerVersion: v2.6.99
+version: v1.23.13+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.7.99
 agentArgs:
   docker:
     type: boolean

--- a/driver_data/k3s/releases/v1.23.4+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.4+k3s1.yaml
@@ -1,0 +1,106 @@
+version: v1.23.4+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array
+

--- a/driver_data/k3s/releases/v1.23.6+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.6+k3s1.yaml
@@ -1,0 +1,105 @@
+version: v1.23.6+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.23.7+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.23.7+k3s1.yaml
@@ -1,0 +1,107 @@
+version: v1.23.7+k3s1
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.23.8+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.23.8+k3s2.yaml
@@ -1,0 +1,109 @@
+version: v1.23.8+k3s2
+minChannelServerVersion: v2.6.4-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.24.2+k3s2.yaml
+++ b/driver_data/k3s/releases/v1.24.2+k3s2.yaml
@@ -1,0 +1,109 @@
+version: v1.24.2+k3s2
+minChannelServerVersion: v2.6.7-alpha1
+maxChannelServerVersion: v2.6.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.24.4+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.24.4+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.24.4+k3s1
+minChannelServerVersion: v2.6.7-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.24.6+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.24.6+k3s1.yaml
@@ -1,0 +1,109 @@
+version: v1.24.6+k3s1
+minChannelServerVersion: v2.6.7-alpha1
+maxChannelServerVersion: v2.7.99
+agentArgs:
+  docker:
+    type: boolean
+    default: false
+  pause-image:
+    type: string
+  snapshotter:
+    type: string
+  flannel-iface:
+    type: string
+  flannel-conf:
+    type: string
+  kubelet-arg:
+    type: array
+  kube-proxy-arg:
+    type: array
+  protect-kernel-defaults:
+    type: boolean
+    default: false
+  resolv-conf:
+    type: string
+  selinux:
+    type: boolean
+    default: false
+  system-default-registry:
+    type: string
+featureVersions:
+  encryption-key-rotation: "2.0.0"
+serverArgs:
+  cluster-cidr:
+    type: string
+  cluster-dns:
+    type: string
+  cluster-domain:
+    type: string
+  datastore-endpoint:
+    type: string
+  datastore-cafile:
+    type: string
+  datastore-certfile:
+    type: string
+  datastore-keyfile:
+    type: string
+  default-local-storage-path:
+    type: string
+  disable:
+    type: array
+    options:
+    - coredns
+    - servicelb
+    - traefik
+    - local-storage
+    - metrics-server
+  disable-apiserver:
+    type: boolean
+    default: false
+  disable-cloud-controller:
+    type: boolean
+    default: false
+  disable-controller-manager:
+    type: boolean
+    default: false
+  disable-etcd:
+    type: boolean
+    default: false
+  disable-kube-proxy:
+    type: boolean
+    default: false
+  disable-network-policy:
+    type: boolean
+    default: false
+  disable-scheduler:
+    type: boolean
+    default: false
+  egress-selector-mode:
+    type: string
+  etcd-arg:
+    type: array
+  etcd-expose-metrics:
+    type: boolean
+    default: false
+  flannel-backend:
+    type: enum
+    options:
+    - none
+    - vxlan
+    - ipsec
+    - host-gw
+    - wireguard
+  kube-apiserver-arg:
+    type: array
+  kube-controller-manager-arg:
+    type: array
+  kube-cloud-controller-manager-arg:
+    type: array
+  kube-scheduler-arg:
+    type: array
+  secrets-encryption:
+    type: boolean
+    default: false
+  service-cidr:
+    type: string
+  service-node-port-range:
+    type: string
+  tls-san:
+    type: array

--- a/driver_data/k3s/releases/v1.24.7+k3s1.yaml
+++ b/driver_data/k3s/releases/v1.24.7+k3s1.yaml
@@ -1,13 +1,11 @@
-version: v1.22.13+k3s1
-minChannelServerVersion: v2.6.3-alpha1
-maxChannelServerVersion: v2.6.99
+version: v1.24.7+k3s1
+minChannelServerVersion: v2.6.7-alpha1
+maxChannelServerVersion: v2.7.99
 agentArgs:
   docker:
     type: boolean
     default: false
   pause-image:
-    type: string
-  snapshotter:
     type: string
   flannel-iface:
     type: string
@@ -25,6 +23,8 @@ agentArgs:
   selinux:
     type: boolean
     default: false
+  snapshotter:
+    type: string
   system-default-registry:
     type: string
 featureVersions:

--- a/rke/k8s_defaults.go
+++ b/rke/k8s_defaults.go
@@ -67,8 +67,6 @@ func initData() {
 }
 
 func loadChannelInfo() {
-	// closures process the data, allowing us to reuse readFiles in different contexts
-
 	readFiles("./driver_data/k3s", func(d map[string]interface{}) {
 		for k, v := range d {
 			DriverData.K3S[k] = v


### PR DESCRIPTION
# What this change is about
The goal is to provide a more straight forward way of generating the yaml which "go generate" uses to build the data.json.
More specifically, this provides the groundwork to stop using the anchors, pointers, and merge operators in the yaml files.
These yaml artifacts make the process for updating and verifying channels.yaml error prone and more difficult.

# Compatibility
This request produces no changes in the outcome of the "go generate" function ("go generate" provides an identical data.json), but it provides the maintainers a more reliable process for updating and verifying the channels.yaml.

There is no change for the channels-rke2.yaml, even though it also uses the new parsing method. This shows that the new method is backwards compatible. 

# Why there so many new files
This may seem like a massive change at first with the addition of many new files, but the majority of the files are simply a breakdown of what is already expressed in the current channels.yaml, all of the new files are yaml expressed explicitly for "go generate" to parse. This explicit expression of the yaml (rather than using anchors, pointers, and the deprecated merge operator) provides a simpler workflow for distribution release captains and a more reliable outcome for the "go generate" method. This new method also prepares us for when yaml-go no longer supports the yaml merge operator.

# How does it work
Rather than a single file for the channels.yaml we now have a driver_data directory. In the driver_data directory we put yaml files which are parsed into the DriverData struct. The "go generate" function now looks in the driver_data/k3s directory to parse channels.yaml objects not related to the "release" json objects. Directories are ignored (this is not a recursive search), and the yaml in this directory is expected to belong to a unique object. The "go generate" function then looks in the driver_data/k3s/releases directory and reads every file as a "release" object added to the "releases" json array. Finally, the "go generate" function reads the "channels-rke2.yaml" file as normal.

# How does this effect the process
Rather than editing the channels.yaml and using yaml anchors, pointers, and merges the maintainer creates a new file in the driver_data/k3s/releases directory for the new release and adds the objects to the file as necessary (all items are explicit). This results in more lines overall, but less confusion and fewer mistakes.

Signed-off-by: matttrach <matttrach@gmail.com>