### PR TITLE
hide k8s 1.22 and below on Rancher 2.7 and RKE 1.4

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -597,7 +597,7 @@ releases:
       <<: *featureVersions-v1-21-14-rke2r1
   - version: v1.22.13+rke2r1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: &serverArgs-v1
       <<: *serverArgs-v1-22-11-rke2r1
     agentArgs: &agentArgs-v1
@@ -617,7 +617,7 @@ releases:
       <<: *featureVersions-v1-22-11-rke2r1
   - version: v1.22.15+rke2r1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v1-22-11-rke2r1
     agentArgs: *agentArgs-v1-22-11-rke2r1
     charts: &charts-v1-22-15-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -223,14 +223,14 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.22.13+k3s1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
     featureVersions: *featureVersions-v1
   # v1.22.14+k3s1 was never released
   - version: v1.22.15+k3s1
     minChannelServerVersion: v2.6.3-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -11616,7 +11616,9 @@
   },
   "v1.19": {
    "minRKEVersion": "1.2.0-rc0",
-   "minRancherVersion": "2.5.0-rc0"
+   "maxRKEVersion": "1.3.99",
+   "minRancherVersion": "2.5.0-rc0",
+   "maxRancherVersion": "2.6.99"
   },
   "v1.19.13-rancher1-1": {
    "minRKEVersion": "1.2.0-rc0",
@@ -11668,7 +11670,9 @@
   },
   "v1.20": {
    "minRKEVersion": "1.2.0-rc0",
-   "minRancherVersion": "2.5.6-rc0"
+   "maxRKEVersion": "1.3.99",
+   "minRancherVersion": "2.5.6-rc0",
+   "maxRancherVersion": "2.6.99"
   },
   "v1.20.10-rancher1-1": {
    "minRKEVersion": "1.2.0-rc0",
@@ -11736,7 +11740,13 @@
   },
   "v1.21": {
    "minRKEVersion": "1.3.0-rc0",
-   "minRancherVersion": "2.6.0-rc0"
+   "maxRKEVersion": "1.3.99",
+   "minRancherVersion": "2.6.0-rc0",
+   "maxRancherVersion": "2.6.99"
+  },
+  "v1.22": {
+   "maxRKEVersion": "1.3.99",
+   "maxRancherVersion": "2.6.99"
   },
   "v1.22.10-rancher1-1": {
    "minRKEVersion": "1.3.3-rc0",
@@ -15319,7 +15329,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -15474,7 +15484,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22021,7 +22031,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -22271,7 +22281,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.3-alpha1",
     "serverArgs": {
      "audit-policy-file": {

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -504,6 +504,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.19": {
 			MinRancherVersion: "2.5.0-rc0",
 			MinRKEVersion:     "1.2.0-rc0",
+			MaxRancherVersion: "2.6.99",
+			MaxRKEVersion:     "1.3.99",
 		},
 		"v1.19.13-rancher1-1": {
 			MinRancherVersion: "2.5.0-rc0",
@@ -556,6 +558,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.20": {
 			MinRancherVersion: "2.5.6-rc0",
 			MinRKEVersion:     "1.2.0-rc0",
+			MaxRancherVersion: "2.6.99",
+			MaxRKEVersion:     "1.3.99",
 		},
 		"v1.20.9-rancher1-1": {
 			MinRancherVersion: "2.5.6-rc0",
@@ -624,6 +628,12 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.21": {
 			MinRancherVersion: "2.6.0-rc0",
 			MinRKEVersion:     "1.3.0-rc0",
+			MaxRancherVersion: "2.6.99",
+			MaxRKEVersion:     "1.3.99",
+		},
+		"v1.22": {
+			MaxRancherVersion: "2.6.99",
+			MaxRKEVersion:     "1.3.99",
 		},
 		"v1.23": {
 			MinRancherVersion: "2.6.4-patch0",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/39239
This PR is to hide k8s 1.22 and below on Rancher 2.7 and RKE 1.4
It covers 	RKE, RKE2, and  K3S 