### PR TITLE
Update max rancher version for latest rke2 releases to be rancher v2.6.99

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -773,7 +773,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.23.13+rke2r1
     minChannelServerVersion: v2.6.4-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v1-23-8-rke2r1
     agentArgs: *agentArgs-v1-23-8-rke2r1
     charts: &charts-v1-23-13-rke2r1
@@ -844,7 +844,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.24.7+rke2r1
     minChannelServerVersion: v2.6.7-alpha1
-    maxChannelServerVersion: v2.7.99
+    maxChannelServerVersion: v2.6.99
     serverArgs: *serverArgs-v1-24-2-rke2r1
     agentArgs: *agentArgs-v1-24-2-rke2r1
     charts: &charts-v1-24-7-rke2r1

--- a/data/data.json
+++ b/data/data.json
@@ -24310,7 +24310,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.4-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -25060,7 +25060,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.7.99",
+    "maxChannelServerVersion": "v2.6.99",
     "minChannelServerVersion": "v2.6.7-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
Found when validating https://github.com/rancher/rancher/issues/39507.

Without this change, the UI will incorrectly show v1.24 as experimental in rancher 2.6:
![image](https://user-images.githubusercontent.com/55997940/201190367-303a0921-23b3-404b-8826-680200c50164.png)

With this change, it should be correct:
<img width="610" alt="image" src="https://user-images.githubusercontent.com/55997940/201190553-1e92a521-afb7-4c0f-b2c4-460627ace172.png">
