### PR TITLE
remove k3s v1.23.12, not v1.21.13

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -168,7 +168,11 @@ releases:
     maxChannelServerVersion: v2.6.4
     serverArgs: *serverArgs-v2
     agentArgs: *agentArgs-v2
-  # v1.21.13+k3s1 was never released through KDM
+  - version: v1.21.13+k3s1
+    minChannelServerVersion: v2.6.3-alpha1
+    maxChannelServerVersion: v2.6.4
+    serverArgs: *serverArgs-v2
+    agentArgs: *agentArgs-v2
   - version: v1.21.14+k3s1
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.4
@@ -260,12 +264,7 @@ releases:
     agentArgs: *agentArgs-v2
     featureVersions: *featureVersions-v1
   #  v1.23.11+k3s1 was never released
-  - version: v1.23.12+k3s1
-    minChannelServerVersion: v2.6.4-alpha1
-    maxChannelServerVersion: v2.6.99
-    serverArgs: *serverArgs-v3
-    agentArgs: *agentArgs-v2
-    featureVersions: *featureVersions-v1
+  #  v1.23.12+k3s1 was never released through KDM 
   - version: v1.23.13+k3s1
     minChannelServerVersion: v2.6.4-alpha1
     maxChannelServerVersion: v2.6.99

--- a/data/data.json
+++ b/data/data.json
@@ -13969,6 +13969,155 @@
       "type": "string"
      }
     },
+    "maxChannelServerVersion": "v2.6.4",
+    "minChannelServerVersion": "v2.6.3-alpha1",
+    "serverArgs": {
+     "cluster-cidr": {
+      "type": "string"
+     },
+     "cluster-dns": {
+      "type": "string"
+     },
+     "cluster-domain": {
+      "type": "string"
+     },
+     "datastore-cafile": {
+      "type": "string"
+     },
+     "datastore-certfile": {
+      "type": "string"
+     },
+     "datastore-endpoint": {
+      "type": "string"
+     },
+     "datastore-keyfile": {
+      "type": "string"
+     },
+     "default-local-storage-path": {
+      "type": "string"
+     },
+     "disable": {
+      "options": [
+       "coredns",
+       "servicelb",
+       "traefik",
+       "local-storage",
+       "metrics-server"
+      ],
+      "type": "array"
+     },
+     "disable-apiserver": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-cloud-controller": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-controller-manager": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-etcd": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-kube-proxy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-network-policy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-scheduler": {
+      "default": false,
+      "type": "boolean"
+     },
+     "etcd-arg": {
+      "type": "array"
+     },
+     "etcd-expose-metrics": {
+      "default": false,
+      "type": "boolean"
+     },
+     "flannel-backend": {
+      "options": [
+       "none",
+       "vxlan",
+       "ipsec",
+       "host-gw",
+       "wireguard"
+      ],
+      "type": "enum"
+     },
+     "kube-apiserver-arg": {
+      "type": "array"
+     },
+     "kube-cloud-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-scheduler-arg": {
+      "type": "array"
+     },
+     "secrets-encryption": {
+      "default": false,
+      "type": "boolean"
+     },
+     "service-cidr": {
+      "type": "string"
+     },
+     "service-node-port-range": {
+      "type": "string"
+     },
+     "tls-san": {
+      "type": "array"
+     }
+    },
+    "version": "v1.21.13+k3s1"
+   },
+   {
+    "agentArgs": {
+     "docker": {
+      "default": false,
+      "type": "boolean"
+     },
+     "flannel-conf": {
+      "type": "string"
+     },
+     "flannel-iface": {
+      "type": "string"
+     },
+     "kube-proxy-arg": {
+      "type": "array"
+     },
+     "kubelet-arg": {
+      "type": "array"
+     },
+     "pause-image": {
+      "type": "string"
+     },
+     "protect-kernel-defaults": {
+      "default": false,
+      "type": "boolean"
+     },
+     "resolv-conf": {
+      "type": "string"
+     },
+     "selinux": {
+      "default": false,
+      "type": "boolean"
+     },
+     "snapshotter": {
+      "type": "string"
+     },
+     "system-default-registry": {
+      "type": "string"
+     }
+    },
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
@@ -16197,161 +16346,6 @@
      }
     },
     "version": "v1.23.10+k3s1"
-   },
-   {
-    "agentArgs": {
-     "docker": {
-      "default": false,
-      "type": "boolean"
-     },
-     "flannel-conf": {
-      "type": "string"
-     },
-     "flannel-iface": {
-      "type": "string"
-     },
-     "kube-proxy-arg": {
-      "type": "array"
-     },
-     "kubelet-arg": {
-      "type": "array"
-     },
-     "pause-image": {
-      "type": "string"
-     },
-     "protect-kernel-defaults": {
-      "default": false,
-      "type": "boolean"
-     },
-     "resolv-conf": {
-      "type": "string"
-     },
-     "selinux": {
-      "default": false,
-      "type": "boolean"
-     },
-     "snapshotter": {
-      "type": "string"
-     },
-     "system-default-registry": {
-      "type": "string"
-     }
-    },
-    "featureVersions": {
-     "encryption-key-rotation": "2.0.0"
-    },
-    "maxChannelServerVersion": "v2.6.99",
-    "minChannelServerVersion": "v2.6.4-alpha1",
-    "serverArgs": {
-     "cluster-cidr": {
-      "type": "string"
-     },
-     "cluster-dns": {
-      "type": "string"
-     },
-     "cluster-domain": {
-      "type": "string"
-     },
-     "datastore-cafile": {
-      "type": "string"
-     },
-     "datastore-certfile": {
-      "type": "string"
-     },
-     "datastore-endpoint": {
-      "type": "string"
-     },
-     "datastore-keyfile": {
-      "type": "string"
-     },
-     "default-local-storage-path": {
-      "type": "string"
-     },
-     "disable": {
-      "options": [
-       "coredns",
-       "servicelb",
-       "traefik",
-       "local-storage",
-       "metrics-server"
-      ],
-      "type": "array"
-     },
-     "disable-apiserver": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-cloud-controller": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-controller-manager": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-etcd": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-kube-proxy": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-network-policy": {
-      "default": false,
-      "type": "boolean"
-     },
-     "disable-scheduler": {
-      "default": false,
-      "type": "boolean"
-     },
-     "egress-selector-mode": {
-      "type": "string"
-     },
-     "etcd-arg": {
-      "type": "array"
-     },
-     "etcd-expose-metrics": {
-      "default": false,
-      "type": "boolean"
-     },
-     "flannel-backend": {
-      "options": [
-       "none",
-       "vxlan",
-       "ipsec",
-       "host-gw",
-       "wireguard"
-      ],
-      "type": "enum"
-     },
-     "kube-apiserver-arg": {
-      "type": "array"
-     },
-     "kube-cloud-controller-manager-arg": {
-      "type": "array"
-     },
-     "kube-controller-manager-arg": {
-      "type": "array"
-     },
-     "kube-scheduler-arg": {
-      "type": "array"
-     },
-     "secrets-encryption": {
-      "default": false,
-      "type": "boolean"
-     },
-     "service-cidr": {
-      "type": "string"
-     },
-     "service-node-port-range": {
-      "type": "string"
-     },
-     "tls-san": {
-      "type": "array"
-     }
-    },
-    "version": "v1.23.12+k3s1"
    },
    {
     "agentArgs": {


### PR DESCRIPTION
It was a mistake to remove v1.21.13, need to remove v1.23.12 because we're already releasing a later version - v1.23.13. 