### PR TITLE
[v2.6] add preserveUnknownFields: false to crd, fix The CustomResourceDefini…

### DIFF
--- a/rke/templates/calico_v3.22.go
+++ b/rke/templates/calico_v3.22.go
@@ -746,6 +746,7 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2365,6 +2366,7 @@ spec:
     plural: ipamblocks
     singular: ipamblock
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:

--- a/rke/templates/canal_v3.22.go
+++ b/rke/templates/canal_v3.22.go
@@ -741,6 +741,7 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2358,6 +2359,7 @@ spec:
     plural: ipamblocks
     singular: ipamblock
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:


### PR DESCRIPTION
* add `preserveUnknownFields: false` to felixconfiguration and ipamblock crd, fix error: The CustomResourceDefinitionis invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema
* similar issue
https://github.com/rancher/rke/issues/3152
https://github.com/rancher/rancher/issues/40280