### PR TITLE
[v2.7] Bump hyperkube

### DIFF
--- a/rke/k8s_rke_system_images.go
+++ b/rke/k8s_rke_system_images.go
@@ -8331,9 +8331,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			Nodelocal:                 "rancher/mirrored-k8s-dns-node-cache:1.21.1",
 		},
 		// Enabled in Rancher v2.7.2
-		"v1.23.16-rancher1-1": {
+		"v1.23.16-rancher2-1": {
 			Etcd:                      "rancher/mirrored-coreos-etcd:v3.5.3",
-			Kubernetes:                "rancher/hyperkube:v1.23.16-rancher1",
+			Kubernetes:                "rancher/hyperkube:v1.23.16-rancher2",
 			Alpine:                    "rancher/rke-tools:v0.1.88",
 			NginxProxy:                "rancher/rke-tools:v0.1.88",
 			CertDownloader:            "rancher/rke-tools:v0.1.88",
@@ -8595,9 +8595,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			Nodelocal:                 "rancher/mirrored-k8s-dns-node-cache:1.21.1",
 		},
 		// Enabled in Rancher v2.7.2
-		"v1.24.10-rancher1-1": {
+		"v1.24.10-rancher2-1": {
 			Etcd:                      "rancher/mirrored-coreos-etcd:v3.5.4",
-			Kubernetes:                "rancher/hyperkube:v1.24.10-rancher1",
+			Kubernetes:                "rancher/hyperkube:v1.24.10-rancher2",
 			Alpine:                    "rancher/rke-tools:v0.1.88",
 			NginxProxy:                "rancher/rke-tools:v0.1.88",
 			CertDownloader:            "rancher/rke-tools:v0.1.88",
@@ -8683,9 +8683,9 @@ func loadK8sRKESystemImages() map[string]v3.RKESystemImages {
 			Nodelocal:                 "rancher/mirrored-k8s-dns-node-cache:1.21.1",
 		},
 		// Enabled in Rancher v2.7.2
-		"v1.25.6-rancher1-1": {
+		"v1.25.6-rancher2-1": {
 			Etcd:                      "rancher/mirrored-coreos-etcd:v3.5.4",
-			Kubernetes:                "rancher/hyperkube:v1.25.6-rancher1",
+			Kubernetes:                "rancher/hyperkube:v1.25.6-rancher2",
 			Alpine:                    "rancher/rke-tools:v0.1.87",
 			NginxProxy:                "rancher/rke-tools:v0.1.87",
 			CertDownloader:            "rancher/rke-tools:v0.1.87",

--- a/rke/k8s_version_info.go
+++ b/rke/k8s_version_info.go
@@ -51,7 +51,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.25.6-rancher1-1",
+		"default": "v1.25.6-rancher2-1",
 	}
 }
 


### PR DESCRIPTION
Bump hyperkube to `v1.23.16-rancher2`, `v1.24.10-rancher2` and `v1.25.6-rancher2`
Related issue: https://github.com/rancher/rancher/issues/40508