### PR TITLE
[v2.7] pin env var GOLANGCI_LINT

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,6 +2,7 @@ FROM registry.suse.com/bci/golang:1.19
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
+ENV GOLANGCI_LINT v1.50.1
 
 RUN zypper -n install git docker vim less file curl wget python3 python3-requests python3-PyYAML
 RUN go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
Was added for v2.6 but missing in 2.7 branch. https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.6/Dockerfile.dapper#L5 