### PR TITLE
[v2.6] sync april patch changes to dev-v2.6 branch 

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1073,4 +1073,42 @@ releases:
         repo: rancher-rke2-charts
         version: v3.25.001
     featureVersions: *featureVersions-v1
+  - version: v1.24.13+rke2r1
+    minChannelServerVersion: v2.6.7-alpha1
+    maxChannelServerVersion: v2.6.99
+    serverArgs: *serverArgs-v1-24-2-rke2r1
+    agentArgs: *agentArgs-v1-24-2-rke2r1
+    charts: &charts-v1-24-13-rke2r1
+      <<: *charts-v1-24-11-rke2r1
+      rke2-canal:
+        repo: rancher-rke2-charts
+        version: v3.25.0-build2023020902
+      rke2-cilium:
+        repo: rancher-rke2-charts
+        version: 1.13.000
+      harvester-csi-driver:
+        repo: rancher-rke2-charts
+        version: 0.1.1600
+      rke2-multus:
+        repo: rancher-rke2-charts
+        version: v3.9.3-build2023010902
+      rke2-calico:
+        repo: rancher-rke2-charts
+        version: v3.25.002
+      rke2-calico-crd:
+        repo: rancher-rke2-charts
+        version: v3.25.002
+      rke2-ingress-nginx:
+        repo: rancher-rke2-charts
+        version: 4.5.201
+      rke2-coredns:
+        repo: rancher-rke2-charts
+        version: 1.19.402
+      rancher-vsphere-cpi:
+        repo: rancher-rke2-charts
+        version: 1.4.200
+      rancher-vsphere-csi:
+        repo: rancher-rke2-charts
+        version: 2.6.2-rancher200
+    featureVersions: *featureVersions-v1
 

--- a/channels.yaml
+++ b/channels.yaml
@@ -351,4 +351,9 @@ releases:
     serverArgs: *serverArgs-v3
     agentArgs: *agentArgs-v2
     featureVersions: *featureVersions-v1
-
+  - version: v1.24.13+k3s1
+    minChannelServerVersion: v2.6.7-alpha1
+    maxChannelServerVersion: v2.6.99
+    serverArgs: *serverArgs-v3
+    agentArgs: *agentArgs-v2
+    featureVersions: *featureVersions-v1


### PR DESCRIPTION
Earlier plan was to release KDM from `dev-v2.6-2023-04-patches`, but we're now releasing KDM with Rancher v2.6.12 from `dev-v2.6` branch. 