### PR TITLE
add validation for regsync file

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	RegSyncFilePath = "./regsync.yaml"
+
 	rke2LinuxImageURL   = "https://github.com/rancher/rke2/releases/download/%s/rke2-images-all.linux-amd64.txt"
 	rke2WindowsImageURL = "https://github.com/rancher/rke2/releases/download/%s/rke2-images.windows-amd64.txt"
 	k3sLinuxImageURL    = "https://github.com/k3s-io/k3s/releases/download/%s/k3s-images.txt"
@@ -26,9 +28,9 @@ const (
 	upgradeImage              = "rancher/%s-upgrade:%s"
 	releasesKey               = "releases"
 	templateFilePath          = "./pkg/images/template.go.tmpl"
-	regsyncFilePath           = "./regsync.yaml"
-	linux                     = "linux"
-	window                    = "windows"
+
+	linux  = "linux"
+	window = "windows"
 )
 
 var (
@@ -66,7 +68,7 @@ func GenerateRegSyncFile() {
 	if err != nil {
 		logrus.Fatalf("failed to parse the template file: %v ", err)
 	}
-	file, err := os.Create(regsyncFilePath)
+	file, err := os.Create(RegSyncFilePath)
 	if err != nil {
 		logrus.Fatalf("failed to create the regsync file: %v ", err)
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/41416

This PR is to add the validation for the `regsync.yaml` file.

Note that because we can not merge commits into the release branch now, but the validation tests require the regsync.yaml file in the release branch to run, we have to set the value of `releaseRegSyncURL` to a fork that contains the necessary regsync.yaml file. We will need to switch back to the legit URL after the next release. 