### PR TITLE
use lowercase letters in the image names in the generated regsync.yaml file

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -167,8 +167,8 @@ func getImages(distro string, versions []interface{}) (all []string, err error) 
 			// - rancher/rancher-<distro>-upgrade
 			// - rancher/system-agent-installer-<distro>
 			safeVersion := strings.ReplaceAll(v, "+", "-")
-			upgradeImage := fmt.Sprintf(upgradeImage, distro, safeVersion)
-			systemAgentInstallerImage := fmt.Sprintf(systemAgentInstallerImage, distro, safeVersion)
+			upgradeImage := fmt.Sprintf(upgradeImage, strings.ToLower(distro), safeVersion)
+			systemAgentInstallerImage := fmt.Sprintf(systemAgentInstallerImage, strings.ToLower(distro), safeVersion)
 			all = append(all, upgradeImage, systemAgentInstallerImage)
 		}
 	}

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -10,52 +10,6 @@ defaults:
     - application/vnd.oci.image.manifest.v1+json
     - application/vnd.oci.image.index.v1+json
 sync:
-  - source: docker.io/rancher/K3S-upgrade
-    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/K3S-upgrade'
-    type: repository
-    tags:
-      allow:
-        - v1.23.10-k3s1
-        - v1.23.13-k3s1
-        - v1.23.14-k3s1
-        - v1.23.15-k3s1
-        - v1.23.16-k3s1
-        - v1.23.17-k3s1
-        - v1.24.10-k3s1
-        - v1.24.11-k3s1
-        - v1.24.13-k3s1
-        - v1.24.14-k3s1
-        - v1.24.4-k3s1
-        - v1.24.7-k3s1
-        - v1.24.8-k3s1
-        - v1.24.9-k3s2
-        - v1.25.10-k3s1
-        - v1.25.7-k3s1
-        - v1.25.9-k3s1
-        - v1.26.5-k3s1
-  - source: docker.io/rancher/RKE2-upgrade
-    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/RKE2-upgrade'
-    type: repository
-    tags:
-      allow:
-        - v1.23.10-rke2r1
-        - v1.23.13-rke2r1
-        - v1.23.14-rke2r1
-        - v1.23.15-rke2r1
-        - v1.23.16-rke2r1
-        - v1.23.17-rke2r1
-        - v1.24.10-rke2r1
-        - v1.24.11-rke2r1
-        - v1.24.13-rke2r1
-        - v1.24.14-rke2r1
-        - v1.24.4-rke2r1
-        - v1.24.7-rke2r1
-        - v1.24.8-rke2r1
-        - v1.24.9-rke2r2
-        - v1.25.10-rke2r1
-        - v1.25.7-rke2r1
-        - v1.25.9-rke2r1
-        - v1.26.5-rke2r1
   - source: docker.io/rancher/calico-cni
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/calico-cni'
     type: repository
@@ -272,6 +226,29 @@ sync:
         - v1.25.6-rancher4
         - v1.25.9-rancher2
         - v1.26.4-rancher2
+  - source: docker.io/rancher/k3s-upgrade
+    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/k3s-upgrade'
+    type: repository
+    tags:
+      allow:
+        - v1.23.10-k3s1
+        - v1.23.13-k3s1
+        - v1.23.14-k3s1
+        - v1.23.15-k3s1
+        - v1.23.16-k3s1
+        - v1.23.17-k3s1
+        - v1.24.10-k3s1
+        - v1.24.11-k3s1
+        - v1.24.13-k3s1
+        - v1.24.14-k3s1
+        - v1.24.4-k3s1
+        - v1.24.7-k3s1
+        - v1.24.8-k3s1
+        - v1.24.9-k3s2
+        - v1.25.10-k3s1
+        - v1.25.7-k3s1
+        - v1.25.9-k3s1
+        - v1.26.5-k3s1
   - source: docker.io/rancher/klipper-helm
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/klipper-helm'
     type: repository
@@ -792,8 +769,31 @@ sync:
         - v1.25.9-rke2r1-windows-amd64
         - v1.26.5-rke2r1
         - v1.26.5-rke2r1-windows-amd64
-  - source: docker.io/rancher/system-agent-installer-K3S
-    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-K3S'
+  - source: docker.io/rancher/rke2-upgrade
+    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/rke2-upgrade'
+    type: repository
+    tags:
+      allow:
+        - v1.23.10-rke2r1
+        - v1.23.13-rke2r1
+        - v1.23.14-rke2r1
+        - v1.23.15-rke2r1
+        - v1.23.16-rke2r1
+        - v1.23.17-rke2r1
+        - v1.24.10-rke2r1
+        - v1.24.11-rke2r1
+        - v1.24.13-rke2r1
+        - v1.24.14-rke2r1
+        - v1.24.4-rke2r1
+        - v1.24.7-rke2r1
+        - v1.24.8-rke2r1
+        - v1.24.9-rke2r2
+        - v1.25.10-rke2r1
+        - v1.25.7-rke2r1
+        - v1.25.9-rke2r1
+        - v1.26.5-rke2r1
+  - source: docker.io/rancher/system-agent-installer-k3s
+    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-k3s'
     type: repository
     tags:
       allow:
@@ -815,8 +815,8 @@ sync:
         - v1.25.7-k3s1
         - v1.25.9-k3s1
         - v1.26.5-k3s1
-  - source: docker.io/rancher/system-agent-installer-RKE2
-    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-RKE2'
+  - source: docker.io/rancher/system-agent-installer-rke2
+    target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-rke2'
     type: repository
     tags:
       allow:


### PR DESCRIPTION
Problem:
The following error is reported when running `regsync check --config regsync.yaml` 
```
ERRO[2023-06-16T11:35:05-07:00] Failed parsing source                         error="invalid reference \"docker.io/rancher/K3S-upgrade\", repo must be lowercase" source=docker.io/rancher/K3S-upgrade
ERRO[2023-06-16T11:35:05-07:00] Failed parsing source                         error="invalid reference \"docker.io/rancher/RKE2-upgrade\", repo must be lowercase" source=docker.io/rancher/RKE2-upgrade
ERRO[2023-06-16T11:38:03-07:00] Failed parsing source                         error="invalid reference \"docker.io/rancher/system-agent-installer-K3S\", repo must be lowercase" source=docker.io/rancher/system-agent-installer-K3S
ERRO[2023-06-16T11:38:03-07:00] Failed parsing source                         error="invalid reference \"docker.io/rancher/system-agent-installer-RKE2\", repo must be lowercase" source=docker.io/rancher/system-agent-installer-RKE2
```
Fix:

Use lowercase letters in the image names in the generated regsync.yaml file

