### PR TITLE
cherry-pick the updates on Drone CI from the dev-v2.7 branch 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,9 +11,37 @@ steps:
     image: rancher/dapper:v0.6.0
     commands:
     - dapper ci
+    environment:
+      REGISTRY_ENDPOINT:
+        from_secret: REGISTRY_ENDPOINT
     volumes:
     - name: docker
       path: /var/run/docker.sock
+
+  - name: mirror-images
+    image: rancher/dapper:v0.6.0
+    commands:
+    - dapper mirror-images
+    environment:
+      REGISTRY_ENDPOINT:
+        from_secret: REGISTRY_ENDPOINT
+      REGISTRY_USERNAME:
+        from_secret: REGISTRY_USERNAME
+      REGISTRY_PASSWORD:
+        from_secret: REGISTRY_PASSWORD
+    volumes:
+    - name: docker
+      path: /var/run/docker.sock
+    depends_on:
+    - validate
+    when:
+      ref:
+        include:
+          - "refs/heads/release-v*"
+      event:
+      - push
+      instance:
+      - drone-publish.rancher.io
 
   - name: upload
     pull: default
@@ -31,7 +59,7 @@ steps:
       - push
     depends_on:
     - validate
-
+    - mirror-images
 
   - name: dispatch
     image: curlimages/curl:7.81.0

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,9 +9,10 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \
+        curl -sL https://github.com/regclient/regclient/releases/download/v0.4.8/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_ENV REPO TAG DRONE_TAG REGISTRY_ENDPOINT REGISTRY_USERNAME REGISTRY_PASSWORD
 ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-driver-metadata
 ENV DAPPER_DOCKER_SOCKET true
 ENV HOME ${DAPPER_SOURCE}

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,9 +41,11 @@ Prime images only need to be updated for out-of-band KDM releases, ie KDM releas
 
 A `regsync.yaml` file is generated and used as the source of truth for images to be mirrored. 
 
-1. After the PR containing the OOB KDM release is merged into the target dev branch, such as `dev-v2.7`, 
-we need notify the EIO team to start the image mirroring process by using the `regsync.yaml` file in the target branch. (**Note**: This step will be automated in the near feature)
-1. After the image mirroring is done, we need notify QA release captain to validate the necessary images have been updated.
+The image mirroring process is automated as a step in the Drone CI:
+
+1. After the PR containing the OOB KDM release is merged into the target release branch, such as `release-v2.7`,
+Drone CI is triggered to run the `mirror-images` step which mirrors new images and tags to Rancher Trusted Registry. 
+2. After the Drone CI finishes successfully, we need notify QA release captain to validate the necessary images have been updated.
 
 ### Prepare release notes for KDM (TBD)
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -16,14 +16,8 @@ import (
 )
 
 var (
-	releaseDataURL = "https://releases.rancher.com/kontainer-driver-metadata/%s/data.json"
-
-	// We can not merge commits into the release branch when we are not releasing new versions,
-	// but the validation tests requires the regsync.yaml file in the release branch to run.
-	// As the workaround, we use a URL to a branch which contains the necessary regsync.yaml file.
-	// FIXME: we need to switch back to the legit URL after the next release: uncomment the following line and delete the next
-	// releaseRegSyncURL = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/%s/regsync.yaml"
-	releaseRegSyncURL = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/%s-with-regsync-file/regsync.yaml"
+	releaseDataURL    = "https://releases.rancher.com/kontainer-driver-metadata/%s/data.json"
+	releaseRegSyncURL = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/%s/regsync.yaml"
 )
 
 // imageTags holds images and their tags as nested maps to make the comparison easy

--- a/scripts/mirror-images
+++ b/scripts/mirror-images
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Regsync mirroring images
+regsync once --config ./regsync.yaml

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -26,3 +26,6 @@ fi
 
 echo Checking if released versions are not changed
 go run ./pkg/validation/validation.go release-v2.7
+
+echo Checking the generated regsync.yaml file
+regsync check --config ./regsync.yaml


### PR DESCRIPTION
This PR is to cherry-pick the updates on Drone CI from the dev-v2.7 branch so that we can utilize them in this OOB release process. 