### PR TITLE
Add encrypted key rotation validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/rancher/rke v1.3.0-rc8.0.20210706205346-22b82828ffa0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
 	k8s.io/apimachinery v0.21.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 h1:xUIPaMhvROX9dhPvRCenIJtU78+lbEenGbgqB5hfHCQ=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -180,10 +180,10 @@ func validateDistro(distro string, dev, released kdm.Data) error {
 		for _, r := range raw {
 			release, ok := r.(map[string]interface{})
 			if !ok {
-				return err
+				return errors.New("failed to parse map")
 			}
 			if err := validateEncryptedKeyRotation(release); err != nil {
-				return fmt.Errorf("failed to validate k3s encrypted key rotation: %v", err)
+				return fmt.Errorf("failed to validate k3s encrypted key rotation: %w", err)
 			}
 		}
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -208,13 +209,13 @@ func validateEncryptedKeyRotation(release map[string]interface{}) error {
 		return err
 	}
 	if !foundFeatureVersions {
-		return fmt.Errorf("missing featureVersions on version: %s", version)
+		return errors.New("missing featureVersions on version: " + version)
 	}
 
 	_, foundEncryptionKeyRotation := featureVersions["encryption-key-rotation"]
 
 	if !foundEncryptionKeyRotation {
-		return fmt.Errorf("missing encryption-key-rotation on version: %s", version)
+		return errors.New("missing encryption-key-rotation on version: " + version)
 	}
 
 	return nil

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -195,7 +195,7 @@ func validateEncryptedKeyRotation(release map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	// this is the first version that hasn't reached it's end of life that requires
+	// this is the first version that hasn't reached its end of life that requires
 	// the encrypted-key-rotation key to exist when this validation is being written
 	const firstVersionToCheckEncryptedKeyRotation = "v1.25.11"
 	compareVersions := semver.Compare(firstVersionToCheckEncryptedKeyRotation, version)

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -202,7 +202,7 @@ func validateEncryptedKeyRotation(release map[string]interface{}) error {
 	if compareVersions != 0 && compareVersions != -1 {
 		return nil
 	}
-	logrus.Infof("validating encrypted key rotation key on version: %s", version)
+	logrus.Info("validating encrypted key rotation key on version: " + version)
 
 	featureVersions, foundFeatureVersions, err := unstructured.NestedMap(release, "featureVersions")
 	if err != nil {


### PR DESCRIPTION
This PR adds a validation to check if there is an `encrypted-key-rotation` key in all versions after it was required that haven't reached end of life yet.