### PR TITLE
[v2.8] Add Default K8s version to v1.27 for Rancher 2.8.x

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -385,7 +385,7 @@ releases:
     agentArgs: *agentArgs-v2
     featureVersions: *featureVersions-v1
   - version: v1.24.17+k3s1
-    minChannelServerVersion: v2.8.0-alpha1
+    minChannelServerVersion: v2.6.7-alpha1
     maxChannelServerVersion: v2.8.99
     serverArgs: &serverArgs-v6
       <<: *serverArgs-v5
@@ -430,7 +430,7 @@ releases:
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.25.13+k3s1
-    minChannelServerVersion: v2.8.0-alpha1
+    minChannelServerVersion: v2.7.2-alpha1
     maxChannelServerVersion: v2.8.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
@@ -467,7 +467,7 @@ releases:
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.26.8+k3s1
-    minChannelServerVersion: v2.8.0-alpha1
+    minChannelServerVersion: v2.7.5-alpha1
     maxChannelServerVersion: v2.8.99
     serverArgs: &serverArgs-v8
       <<: *serverArgs-v7

--- a/channels.yaml
+++ b/channels.yaml
@@ -14,6 +14,8 @@ appDefaults:
         defaultVersion: '1.25.x'
       - appVersion: '>= 2.7.5-0 < 2.7.100-0'
         defaultVersion: '1.26.x'
+      - appVersion: '>= 2.8.0-0 < 2.8.100-0'
+        defaultVersion: '1.27.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1


### PR DESCRIPTION
This is a potential fix for https://github.com/rancher/rancher/issues/42814

I tested these changes by updating KDM data in Rancher v2.8-head (96634e1) and the versions are coming up fine. Please refer to the snapshot below:

![Screenshot from 2023-09-14 14-38-55](https://github.com/rancher/kontainer-driver-metadata/assets/32811240/e939665d-471b-46c3-8465-302fadc96620)
