### PR TITLE
[dev v2.8] Remove k8s 1.23 and 1.24 from rancher v2.8.x

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1223,7 +1223,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.24.17+rke2r1
     minChannelServerVersion: v2.6.7-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.7.99
     serverArgs: &serverArgs-v1-24-17-rke1r1
       <<: *serverArgs-v1-24-2-rke2r1
       tls-san-security:

--- a/channels.yaml
+++ b/channels.yaml
@@ -386,7 +386,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.24.17+k3s1
     minChannelServerVersion: v2.6.7-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.7.99
     serverArgs: &serverArgs-v6
       <<: *serverArgs-v5
       tls-san-security:

--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -643,10 +643,14 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.23": {
 			MinRancherVersion: "2.6.4-patch0",
 			MinRKEVersion:     "1.3.8-rc0",
+			MaxRancherVersion: "2.7.99",
+			MaxRKEVersion:     "1.4.99",
 		},
 		"v1.24": {
 			MinRancherVersion: "2.6.7-patch0",
 			MinRKEVersion:     "1.3.13-rc0",
+			MaxRancherVersion: "2.7.99",
+			MaxRKEVersion:     "1.4.99",
 		},
 		"v1.25": {
 			MinRancherVersion: "2.7.2-patch0",


### PR DESCRIPTION
for issue: https://github.com/rancher/rancher/issues/42828

RKE2
- v1.23 latest rke2  v1.23.17+rke2r1 has already the maxRancherVersion as v2.7.99 [ref](https://github.com/rancher/kontainer-driver-metadata/blob/749a0311749a8692dc062938bec24bcf2bbcbf55/channels-rke2.yaml#L889)
- changed maxRancherVersion for v1.24.17+rke2r1 to v2.7.99. All previous v1.24 patch versions have max rancher version as v2.7.99

k3s
- v1.23 latest k3s v1.23.17+k3s1 has already the maxRancherVersion as v2.7.99 [ref](https://github.com/rancher/kontainer-driver-metadata/blob/749a0311749a8692dc062938bec24bcf2bbcbf55/channels.yaml#L312)
- changed maxRancherVersion for v1.24.17+k3s1 to v2.7.99. All previous v1.24 patch versions have max rancher version as v2.7.99

RKE1
- added max rancher and rke versions (2.7.99 and 1.4.99 respecrively) constraints for k8s v1.23 and v1.24