### PR TITLE
Fix incorrect server anchors

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -493,7 +493,7 @@ releases:
   - version: v1.26.11+k3s2
     minChannelServerVersion: v2.7.5-alpha1
     maxChannelServerVersion: v2.8.99
-    serverArgs: *serverArgs-v8
+    serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v4
     featureVersions: *featureVersions-v1
   - version: v1.27.5+k3s1
@@ -511,6 +511,6 @@ releases:
   - version: v1.27.8+k3s2
     minChannelServerVersion: v2.8.0-alpha1
     maxChannelServerVersion: v2.8.99
-    serverArgs: *serverArgs-v8
+    serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v4
     featureVersions: *featureVersions-v1


### PR DESCRIPTION
Previous PR was not rebased before merge. This PR removes the remaining server-arg-v8 anchors. 

Signed-off-by: Derek Nola <derek.nola@suse.com>