### PR TITLE
[v2.8] update default version

### DIFF
--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -56,7 +56,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.27.8-rancher2-1",
+		"default": "v1.27.8-rancher2-2",
 	}
 }
 


### PR DESCRIPTION
Introduced `v1.27.8-rancher2-2` for https://github.com/rancher/rancher/issues/43987, so needs to be updated as the new default. 