### PR TITLE
[v2.7] update default version

### DIFF
--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -54,7 +54,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.26.11-rancher2-1",
+		"default": "v1.26.11-rancher2-2",
 	}
 }
 


### PR DESCRIPTION
Introduced `v1.26.11-rancher2-2` for https://github.com/rancher/rancher/issues/43883, so need to update it as the new default. 