### PR TITLE
Add rancher integration tests to CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,1086 @@ volumes:
 ---
 
 kind: pipeline
+name: provisioning-tests-rke2-1-27
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "27"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-rke2-1-26
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "26"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-rke2-1-25
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "25"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-rke2-1-24
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "24"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-rke2-1-23
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "23"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-k3s-1-27
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "27"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-k3s-1-26
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "26"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-k3s-1-25
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "25"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-k3s-1-24
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "24"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-tests-k3s-1-23
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Provisioning_.*$"
+  KDM_TEST_K8S_MINOR: "23"
+
+steps:
+  - name: provisioning-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-rke2-1-27
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "27"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-rke2-1-26
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "26"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-rke2-1-25
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "25"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-rke2-1-24
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "24"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-rke2-1-23
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "23"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-k3s-1-27
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "27"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-k3s-1-26
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "26"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-k3s-1-25
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "25"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-k3s-1-24
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "24"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
+name: provisioning-operations-tests-k3s-1-23
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "k3s"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+  KDM_TEST_K8S_MINOR: "23"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/dev-v2.*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+
+kind: pipeline
 name: fossa
 
 steps:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,69 @@
-FROM registry.suse.com/bci/golang:1.19
+ARG RANCHER_VERSION=v2.7-head
+
+FROM rancher/rancher:$RANCHER_VERSION as rancher
+
+FROM registry.suse.com/bci/golang:1.20
+
+RUN mkdir -p /var/lib/rancher
+COPY --from=rancher /var/lib/rancher /var/lib/rancher
+
+COPY --from=rancher /run /run
+RUN mkdir -p /usr/share/rancher
+COPY --from=rancher /usr/share/rancher /usr/share/rancher
+
+COPY --from=rancher/k3s:v1.26.4-k3s1 \
+    /bin/blkid \
+    /bin/cni \
+    /bin/conntrack \
+    /bin/containerd \
+    /bin/containerd-shim-runc-v2 \
+    /bin/ethtool \
+    /bin/ip \
+    /bin/ipset \
+    /bin/k3s \
+    /bin/losetup \
+    /bin/pigz \
+    /bin/runc \
+    /bin/which \
+    /bin/aux/xtables-legacy-multi \
+/usr/bin/
+
+COPY --from=rancher \
+    /usr/bin/rancher \
+    /usr/bin/rancher-helm \
+    /usr/bin/rancher-tiller \
+    /usr/bin/rancher-machine \
+/usr/bin/
+
+RUN mkdir -p /go/src/github.com/rancher/kontainer-driver-metadata/.kube
+
+RUN ln -s /usr/bin/cni /usr/bin/bridge && \
+    ln -s /usr/bin/cni /usr/bin/flannel && \
+    ln -s /usr/bin/cni /usr/bin/host-local && \
+    ln -s /usr/bin/cni /usr/bin/loopback && \
+    ln -s /usr/bin/cni /usr/bin/portmap && \
+    ln -s /usr/bin/k3s /usr/bin/crictl && \
+    ln -s /usr/bin/k3s /usr/bin/ctr && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-agent && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-etcd-snapshot && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-server && \
+    ln -s /usr/bin/k3s /usr/bin/kubectl && \
+    ln -s /usr/bin/pigz /usr/bin/unpigz && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-translate && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-translate && \
+    ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/kontainer-driver-metadata/.kube/k3s.yaml
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV GOLANGCI_LINT v1.50.1
+ENV GOLANGCI_LINT v1.52.0
 
-RUN zypper -n install git docker vim less file curl wget
+RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
@@ -12,11 +71,18 @@ RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sL https://github.com/regclient/regclient/releases/download/v0.4.8/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG REGISTRY_ENDPOINT REGISTRY_USERNAME REGISTRY_PASSWORD
+ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_BUILD_EVENT DRONE_TAG \
+    REGISTRY_ENDPOINT REGISTRY_USERNAME REGISTRY_PASSWORD \
+    V2PROV_TEST_DIST V2PROV_TEST_RUN_REGEX KDM_TEST_K8S_MINOR DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-driver-metadata
 ENV DAPPER_DOCKER_SOCKET true
+ARG CI
+ARG DRONE_BUILD_NUMBER
+ENV DAPPER_RUN_ARGS "--privileged --label CI=${CI} --label DRONE_BUILD_NUMBER=${DRONE_BUILD_NUMBER}"
 ENV HOME ${DAPPER_SOURCE}
 ENV GOPATH /go
+VOLUME /var/lib/rancher
+VOLUME /var/lib/kubelet
 WORKDIR ${DAPPER_SOURCE}
 
 ENTRYPOINT ["./scripts/entry"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -71,7 +71,7 @@ RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sL https://github.com/regclient/regclient/releases/download/v0.4.8/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
-ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_BUILD_EVENT DRONE_TAG \
+ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_BUILD_EVENT DRONE_TAG DRONE_COMMIT_BEFORE \
     REGISTRY_ENDPOINT REGISTRY_USERNAME REGISTRY_PASSWORD \
     V2PROV_TEST_DIST V2PROV_TEST_RUN_REGEX KDM_TEST_K8S_MINOR DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-driver-metadata

--- a/scripts/fetch-provisioning-tests
+++ b/scripts/fetch-provisioning-tests
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -ex
+
+cd $(dirname $0)/..
+
+# Create binary directory for running provisioning tests
+mkdir -p "./bin"
+BIN_DIR="$(realpath ./bin)"
+
+TMP_DIR=$(mktemp -d)
+
+pushd "$TMP_DIR"
+
+IMAGE_REPO=${IMAGE_REPO:-rancher/rancher}
+IMAGE_TAG=${IMAGE_TAG:-v2.7-head}
+IMAGE=${IMAGE:-$IMAGE_REPO:$IMAGE_TAG}
+
+# Inspect image, get server version and extract rancher commit 
+if [ -n "$RANCHER_COMMIT" ]; then
+  RANCHER_COMMIT=$(awk -F '=' '{print $2}' <<< "$CATTLE_SERVER_VERSION")
+  case $RANCHER_COMMIT in *-head)
+    # If the rancher commit ends with '-head', it is usually of the form 'v2.x-<COMMIT>-head', so extract everything between dashes
+    RANCHER_COMMIT=$(awk -F '[-]' '{print $2}' <<< "$RANCHER_COMMIT");;
+  esac
+fi
+
+mkdir -p rancher
+
+# Although using the commit so the image matches the source code, use the default branch associated with that release line
+# Git clones must have a branch, and the release branch is likely to contain the commit anyway
+GIT_URL=${GIT_URL:-https://github.com/rancher/rancher.git}
+GIT_BRANCH=${GIT_BRANCH:-release/v2.7}
+
+git clone --depth 1 -b $GIT_BRANCH $GIT_URL ./rancher
+
+export RANCHER_DIR=$TMP_DIR/rancher
+
+# Checkout commit image was built on
+pushd ./rancher
+
+git checkout $RANCHER_COMMIT
+
+mkdir -p "$RANCHER_DIR/bin"
+
+cp /usr/bin/rancher "$RANCHER_DIR/bin/rancher"
+
+popd

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -x
+
+cd "$(dirname "$0")/.." || exit 1
+
+# If not running in CI, populate k8s versions for testing
+if [ "$V2PROV_TEST_DIST" != "rke2" ] && [ "$V2PROV_TEST_DIST" != "k3s" ]; then
+  export V2PROV_TEST_DIST=rke2
+fi
+
+# If not running in CI, run everything applicable for KDM
+if [ -z "${V2PROV_TEST_RUN_REGEX}" ]; then
+  export V2PROV_TEST_RUN_REGEX="^Test_(Provisioning|Operation)_.*$"
+fi
+
+# Select relevant channels file for parsing test version from
+
+if [ -z "${CHANNELS_FILE}" ]; then
+  case "$V2PROV_TEST_DIST" in
+  k3s)
+    export CHANNELS_FILE=channels.yaml
+    ;;
+  rke2 | *)
+    export CHANNELS_FILE=channels-rke2.yaml
+    ;;
+  esac
+fi
+
+if ! ./scripts/test-run-required.sh; then
+  exit
+fi
+
+set -ex
+
+# Copy local KDM data to expected path so we do not have to cold-start during provisioning tests
+METADATA_DIR=/var/lib/rancher-data/driver-metadata
+
+mkdir -p $METADATA_DIR
+
+cp ./data/data.json "$METADATA_DIR"
+
+# Create dummy git repo to serve KDM data via git branch
+TMP_DIR="$(mktemp -d)"
+
+cp -r . "$TMP_DIR"
+
+pushd "$TMP_DIR"
+
+# Need to create dummy KDM branch for rancher to clone from
+git checkout -b kdm-prov-tests
+
+if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+  git -c user.name='Rancher CI' -c user.email='ci@rancher.com' commit -a -m "KDM Provisioning Tests"
+fi
+
+popd
+
+# Configure Rancher KDM setting for provisioning tests
+export CATTLE_RKE_METADATA_CONFIG="{\"refresh-interval-minutes\":1440,\"url\":\"file://$TMP_DIR/.git\",\"branch\":\"kdm-prov-tests\"}"
+
+# Select k8s version based on latest applicable patch version from desired minor (defaults to latest if running locally)
+if [ -z "${SOME_K8S_VERSION}" ]; then
+  if [ -n "${KDM_TEST_K8S_MINOR}" ]; then
+    # Get git diff in relevant channel file, find all added versions matching k8s minor, and get the last one
+    # There should never be a version of a given distro with multiple patches on the same minor added at the same time
+    # This command should be in sync with the one in test-run-required.sh
+    SOME_K8S_VERSION=$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)" | sed 's/\(^\+\s\+- version: \)//' | tail -n 1)
+  else
+    # Only possible when not running in CI and env var is not provided, in this case just use latest from data.json
+    SOME_K8S_VERSION=$(jq -r ".$V2PROV_TEST_DIST.releases[-1].version" <"$METADATA_DIR/data.json")
+  fi
+  export SOME_K8S_VERSION
+fi
+
+# Copy rancher provisioning tests, and enter directory they exist
+source ./scripts/fetch-provisioning-tests
+
+cd "$RANCHER_DIR"
+
+# Uncomment to get provisioning tests to write commands being run to stdout
+#sed -i '2s/set -e/set -ex/' ./scripts/provisioning-tests
+
+# Uncomment to get startup logs. Don't leave them on because it slows drone down too much
+#sed -i '110s/#//' ./scripts/provisioning-tests
+#sed -i '111s/#//' ./scripts/provisioning-tests
+#sed -i '141s/#//' ./scripts/provisioning-tests
+
+# Remove superfluous check for UI only bumps in this context
+sed -i -e '3,5d' ./scripts/provisioning-tests
+
+./scripts/provisioning-tests

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -64,7 +64,7 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
     # Get git diff in relevant channel file, find all added versions matching k8s minor, and get the last one
     # There should never be a version of a given distro with multiple patches on the same minor added at the same time
     # This command should be in sync with the one in test-run-required.sh
-    SOME_K8S_VERSION=$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)" | sed 's/\(^\+\s\+- version: \)//' | tail -n 1)
+    SOME_K8S_VERSION=$(git --no-pager diff --no-color -G "^  - version:" $DRONE_COMMIT_BEFORE -- "$CHANNELS_FILE" | grep -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)" | sed 's/\(^\+\s\+- version: \)//' | tail -n 1)
   else
     # Only possible when not running in CI and env var is not provided, in this case just use latest from data.json
     SOME_K8S_VERSION=$(jq -r ".$V2PROV_TEST_DIST.releases[-1].version" <"$METADATA_DIR/data.json")

--- a/scripts/test-run-required.sh
+++ b/scripts/test-run-required.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ex
+
+echo "Checking if rancher integration testing is required"
+echo "Environment variable DRONE_BUILD_EVENT is ${DRONE_BUILD_EVENT}"
+
+if [ -z "$CI" ]; then
+  echo "Not running in CI, rancher integration testing is required"
+  exit 0
+fi
+
+if [ -z "$KDM_TEST_K8S_MINOR" ]; then
+  echo "Error: KDM_TEST_K8S_MINOR not defined. This should not be happening in CI"
+  exit 1
+fi
+
+# Only run check if Drone build event is 'push' or 'pull_request'
+if [ "${DRONE_BUILD_EVENT}" = "push" ] || [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+  # Check if the channels file contains changes to versions from the minor version
+  if [ "$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -c -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)")" -ne 0 ]; then
+    exit 0
+  fi
+fi
+
+echo "Skipping CI, no changes detected for relevant minor version"
+exit 1

--- a/scripts/test-run-required.sh
+++ b/scripts/test-run-required.sh
@@ -14,10 +14,15 @@ if [ -z "$KDM_TEST_K8S_MINOR" ]; then
   exit 1
 fi
 
+if [ -z "$DRONE_COMMIT_BEFORE" ]; then
+  echo "Error: DRONE_COMMIT_BEFORE not defined. This should not be happening in CI"
+  exit 1
+fi
+
 # Only run check if Drone build event is 'push' or 'pull_request'
 if [ "${DRONE_BUILD_EVENT}" = "push" ] || [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
   # Check if the channels file contains changes to versions from the minor version
-  if [ "$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -c -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)")" -ne 0 ]; then
+  if [ "$(git --no-pager diff --no-color -G "^  - version:" $DRONE_COMMIT_BEFORE -- "$CHANNELS_FILE" | grep -c -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)")" -ne 0 ]; then
     exit 0
   fi
 fi

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -3,7 +3,6 @@ set -e
 
 cd $(dirname $0)/..
 
-
 echo Running go mod tidy
 go mod tidy
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/44360

Backport of https://github.com/rancher/kontainer-driver-metadata/pull/1289 with minor changes to target v2.7 instead of v2.8.

I have not finished local or remote validation of these CI pipelines, but will before merging.

Update: includes dc708ec4dbe202200ceb831162f604283bb3ed8b from https://github.com/rancher/kontainer-driver-metadata/pull/1316