### PR TITLE
Use DRONE_COMMIT_BEFORE for KDM tests

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -76,7 +76,7 @@ RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sL https://github.com/regclient/regclient/releases/download/v0.4.8/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
-ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_BUILD_EVENT DRONE_TAG \
+ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_BUILD_EVENT DRONE_TAG DRONE_COMMIT_BEFORE \
     REGISTRY_ENDPOINT REGISTRY_USERNAME REGISTRY_PASSWORD \
     V2PROV_TEST_DIST V2PROV_TEST_RUN_REGEX KDM_TEST_K8S_MINOR DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/kontainer-driver-metadata

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -64,7 +64,7 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
     # Get git diff in relevant channel file, find all added versions matching k8s minor, and get the last one
     # There should never be a version of a given distro with multiple patches on the same minor added at the same time
     # This command should be in sync with the one in test-run-required.sh
-    SOME_K8S_VERSION=$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)" | sed 's/\(^\+\s\+- version: \)//' | tail -n 1)
+    SOME_K8S_VERSION=$(git --no-pager diff --no-color -G "^  - version:" $DRONE_COMMIT_BEFORE -- "$CHANNELS_FILE" | grep -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)" | sed 's/\(^\+\s\+- version: \)//' | tail -n 1)
   else
     # Only possible when not running in CI and env var is not provided, in this case just use latest from data.json
     SOME_K8S_VERSION=$(jq -r ".$V2PROV_TEST_DIST.releases[-1].version" <"$METADATA_DIR/data.json")

--- a/scripts/test-run-required.sh
+++ b/scripts/test-run-required.sh
@@ -14,10 +14,15 @@ if [ -z "$KDM_TEST_K8S_MINOR" ]; then
   exit 1
 fi
 
+if [ -z "$DRONE_COMMIT_BEFORE" ]; then
+  echo "Error: DRONE_COMMIT_BEFORE not defined. This should not be happening in CI"
+  exit 1
+fi
+
 # Only run check if Drone build event is 'push' or 'pull_request'
 if [ "${DRONE_BUILD_EVENT}" = "push" ] || [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
   # Check if the channels file contains changes to versions from the minor version
-  if [ "$(git --no-pager diff --no-color -G "^  - version:" HEAD~1 -- "$CHANNELS_FILE" | grep -c -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)")" -ne 0 ]; then
+  if [ "$(git --no-pager diff --no-color -G "^  - version:" $DRONE_COMMIT_BEFORE -- "$CHANNELS_FILE" | grep -c -P "(^\+\s+- version: v1.$KDM_TEST_K8S_MINOR)")" -ne 0 ]; then
     exit 0
   fi
 fi


### PR DESCRIPTION
Continuation of #1314 

https://github.com/rancher/rancher/issues/44360

Turns out `HEAD~1` doesn't work if you have more than one commit, who would've thought!

Thought about using intermediary env var to make it CI agnostic but the `.drone.yml` is big enough as it is.