### PR TITLE
[dev-v2.7] Add 1.27 for k3s and rke2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -12,7 +12,7 @@ appDefaults:
         defaultVersion: '1.24.x'
       - appVersion: '>= 2.7.2-0 < 2.7.5-0'
         defaultVersion: '1.25.x'
-      - appVersion: '>= 2.7.5-0 < 2.7.100-0'
+      - appVersion: '>= 2.7.5-0 < 2.7.11-0'
         defaultVersion: '1.26.x'
       - appVersion: '>= 2.7.11-0 < 2.7.100-0'
         defaultVersion: '1.27.x'

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1605,8 +1605,25 @@ releases:
         repo: rancher-rke2-charts
         version: 1.14.400
     featureVersions: *featureVersions-v1
+  - version: v1.26.13+rke2r1
+    minChannelServerVersion: v2.7.5-alpha1
+    maxChannelServerVersion: v2.7.99
+    serverArgs: *serverArgs-v1-26-10-rke2r2
+    agentArgs: *agentArgs-v1-25-15-rke2r2
+    charts: &charts-v1-26-13-rke2r1
+      <<: *charts-v1-26-11-rke2r1
+      rke2-metrics-server:
+        repo: rancher-rke2-charts
+        version: 2.11.100-build2023051511
+      rke2-multus:
+        repo: rancher-rke2-charts
+        version: v4.0.2-build2023081107
+      rke2-coredns:
+        repo: rancher-rke2-charts
+        version: 1.24.008
+    featureVersions: *featureVersions-v1
   - version: v1.27.5+rke2r1
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: &serverArgs-v1-27-5-rke2r1
       <<: *serverArgs-v1-24-2-rke2r1
@@ -1635,7 +1652,7 @@ releases:
         version: 1.24.004
     featureVersions: *featureVersions-v1
   - version: v1.27.7+rke2r2
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: &serverArgs-v1-27-7-rke2r2
       <<: *serverArgs-v1-27-5-rke2r1
@@ -1667,7 +1684,7 @@ releases:
         version: 1.7.302
     featureVersions: *featureVersions-v1
   - version: v1.27.8+rke2r1
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: *serverArgs-v1-27-7-rke2r2
     agentArgs: *agentArgs-v1-25-15-rke2r2
@@ -1685,4 +1702,21 @@ releases:
       rke2-cilium:
         repo: rancher-rke2-charts
         version: 1.14.400
+    featureVersions: *featureVersions-v1
+  - version: v1.27.10+rke2r1
+    minChannelServerVersion: v2.7.11-alpha1
+    maxChannelServerVersion: v2.7.99
+    serverArgs: *serverArgs-v1-27-7-rke2r2
+    agentArgs: *agentArgs-v1-25-15-rke2r2
+    charts: &charts-v1-27-10-rke2r1
+      <<: *charts-v1-27-8-rke2r1
+      rke2-metrics-server:
+        repo: rancher-rke2-charts
+        version: 2.11.100-build2023051511
+      rke2-multus:
+        repo: rancher-rke2-charts
+        version: v4.0.2-build2023081107
+      rke2-coredns:
+        repo: rancher-rke2-charts
+        version: 1.24.008
     featureVersions: *featureVersions-v1

--- a/channels.yaml
+++ b/channels.yaml
@@ -12,7 +12,7 @@ appDefaults:
         defaultVersion: '1.24.x'
       - appVersion: '>= 2.7.2-0 < 2.7.5-0'
         defaultVersion: '1.25.x'
-      - appVersion: '>= 2.7.5-0 < 2.7.100-0'
+      - appVersion: '>= 2.7.5-0 < 2.7.11-0'
         defaultVersion: '1.26.x'
       - appVersion: '>= 2.7.11-0 < 2.7.100-0'
         defaultVersion: '1.27.x'

--- a/channels.yaml
+++ b/channels.yaml
@@ -496,21 +496,41 @@ releases:
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v4
     featureVersions: *featureVersions-v1
+  - version: v1.26.13+k3s2
+    minChannelServerVersion: v2.7.5-alpha1
+    maxChannelServerVersion: v2.7.99
+    serverArgs: &serverArgs-v7
+      <<: *serverArgs-v6
+      embedded-registry:
+        type: boolean
+    agentArgs: &agentArgs-v5
+      <<: *agentArgs-v4
+      default-runtime:
+        type: string
+      disable-default-registry-endpoint:
+        type: boolean
+    featureVersions: *featureVersions-v1
   - version: v1.27.5+k3s1
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.27.7+k3s2
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.27.8+k3s2
-    minChannelServerVersion: v2.7.11
+    minChannelServerVersion: v2.7.11-alpha1
     maxChannelServerVersion: v2.7.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v4
+    featureVersions: *featureVersions-v1
+  - version: v1.27.10+k3s2
+    minChannelServerVersion: v2.7.11-alpha1
+    maxChannelServerVersion: v2.7.99
+    serverArgs: *serverArgs-v7
+    agentArgs: *agentArgs-v5
     featureVersions: *featureVersions-v1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -51,6 +51,7 @@ sync:
         - v1.8.5-build20221011
         - v1.8.6-build20230406
         - v1.8.6-build20230609
+        - v1.8.6-build20231009
   - source: docker.io/rancher/hardened-cni-plugins
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-cni-plugins'
     type: repository
@@ -67,6 +68,7 @@ sync:
       allow:
         - v1.10.1-build20230406
         - v1.10.1-build20230607
+        - v1.10.1-build20231009
         - v1.9.3-build20220613
         - v1.9.3-build20221011
   - source: docker.io/rancher/hardened-dns-node-cache
@@ -78,6 +80,7 @@ sync:
         - 1.21.2-build20221011
         - 1.22.20-build20230406
         - 1.22.20-build20230607
+        - 1.22.20-build20231010
   - source: docker.io/rancher/hardened-etcd
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-etcd'
     type: repository
@@ -109,6 +112,7 @@ sync:
         - v1.0.2-build20220419
         - v1.0.2-build20221014
         - v1.0.2-build20230607
+        - v1.0.2-build20231009
   - source: docker.io/rancher/hardened-k8s-metrics-server
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-k8s-metrics-server'
     type: repository
@@ -119,6 +123,7 @@ sync:
         - v0.6.2-build20221202
         - v0.6.3-build20230515
         - v0.6.3-build20230607
+        - v0.6.3-build20231009
   - source: docker.io/rancher/hardened-kubernetes
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-kubernetes'
     type: repository
@@ -151,10 +156,12 @@ sync:
         - v1.25.9-rke2r1-build20230412
         - v1.26.10-rke2r2-build20231102
         - v1.26.11-rke2r1-build20231115
+        - v1.26.13-rke2r1-build20240117
         - v1.26.5-rke2r1-build20230518
         - v1.26.6-rke2r1-build20230614
         - v1.26.7-rke2r1-build20230719
         - v1.26.8-rke2r1-build20230824
+        - v1.27.10-rke2r1-build20240117
         - v1.27.5-rke2r1-build20230824
         - v1.27.7-rke2r2-build20231102
         - v1.27.8-rke2r1-build20231115
@@ -169,6 +176,7 @@ sync:
         - v3.9.3-build20230109
         - v4.0.2-build20230707
         - v4.0.2-build20230811
+        - v4.0.2-build20231009
   - source: docker.io/rancher/hardened-sriov-cni
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-cni'
     type: repository
@@ -177,6 +185,7 @@ sync:
         - v2.6.2-build20220419
         - v2.6.3-build20221014
         - v2.6.3-build20230607
+        - v2.6.3-build20231009
   - source: docker.io/rancher/hardened-sriov-network-config-daemon
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-network-config-daemon'
     type: repository
@@ -185,6 +194,7 @@ sync:
         - v1.1.0-build20220419
         - v1.2.0-build20221014
         - v1.2.0-build20230607
+        - v1.2.0-build20231010
   - source: docker.io/rancher/hardened-sriov-network-device-plugin
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-network-device-plugin'
     type: repository
@@ -193,6 +203,7 @@ sync:
         - v3.4.0-build20220419
         - v3.5.1-build20221014
         - v3.5.1-build20230607
+        - v3.5.1-build20231009
   - source: docker.io/rancher/hardened-sriov-network-operator
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-network-operator'
     type: repository
@@ -201,6 +212,7 @@ sync:
         - v1.1.0-build20220419
         - v1.2.0-build20221014
         - v1.2.0-build20230607
+        - v1.2.0-build20231010
   - source: docker.io/rancher/hardened-sriov-network-resources-injector
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-network-resources-injector'
     type: repository
@@ -209,6 +221,7 @@ sync:
         - v1.3-build20220419
         - v1.5-build20221014
         - v1.5-build20230607
+        - v1.5-build20231009
   - source: docker.io/rancher/hardened-sriov-network-webhook
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-sriov-network-webhook'
     type: repository
@@ -217,6 +230,7 @@ sync:
         - v1.1.0-build20220419
         - v1.2.0-build20221014
         - v1.2.0-build20230607
+        - v1.2.0-build20231010
   - source: docker.io/rancher/hardened-whereabouts
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-whereabouts'
     type: repository
@@ -227,6 +241,7 @@ sync:
         - v0.6-build20230109
         - v0.6.1-build20230330
         - v0.6.2-build20230717
+        - v0.6.3-build20240109
   - source: docker.io/rancher/harvester-cloud-provider
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/harvester-cloud-provider'
     type: repository
@@ -318,10 +333,12 @@ sync:
         - v1.25.9-k3s1
         - v1.26.10-k3s2
         - v1.26.11-k3s2
+        - v1.26.13-k3s2
         - v1.26.5-k3s1
         - v1.26.6-k3s1
         - v1.26.7-k3s1
         - v1.26.8-k3s1
+        - v1.27.10-k3s2
         - v1.27.5-k3s1
         - v1.27.7-k3s2
         - v1.27.8-k3s2
@@ -345,6 +362,7 @@ sync:
         - v0.4.0
         - v0.4.3
         - v0.4.4
+        - v0.4.5
   - source: docker.io/rancher/local-path-provisioner
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/local-path-provisioner'
     type: repository
@@ -971,6 +989,8 @@ sync:
         - v1.26.10-rke2r2-windows-amd64
         - v1.26.11-rke2r1
         - v1.26.11-rke2r1-windows-amd64
+        - v1.26.13-rke2r1
+        - v1.26.13-rke2r1-windows-amd64
         - v1.26.5-rke2r1
         - v1.26.5-rke2r1-windows-amd64
         - v1.26.6-rke2r1
@@ -979,6 +999,8 @@ sync:
         - v1.26.7-rke2r1-windows-amd64
         - v1.26.8-rke2r1
         - v1.26.8-rke2r1-windows-amd64
+        - v1.27.10-rke2r1
+        - v1.27.10-rke2r1-windows-amd64
         - v1.27.5-rke2r1
         - v1.27.5-rke2r1-windows-amd64
         - v1.27.7-rke2r2
@@ -1017,10 +1039,12 @@ sync:
         - v1.25.9-rke2r1
         - v1.26.10-rke2r2
         - v1.26.11-rke2r1
+        - v1.26.13-rke2r1
         - v1.26.5-rke2r1
         - v1.26.6-rke2r1
         - v1.26.7-rke2r1
         - v1.26.8-rke2r1
+        - v1.27.10-rke2r1
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1
@@ -1056,10 +1080,12 @@ sync:
         - v1.25.9-k3s1
         - v1.26.10-k3s2
         - v1.26.11-k3s2
+        - v1.26.13-k3s2
         - v1.26.5-k3s1
         - v1.26.6-k3s1
         - v1.26.7-k3s1
         - v1.26.8-k3s1
+        - v1.27.10-k3s2
         - v1.27.5-k3s1
         - v1.27.7-k3s2
         - v1.27.8-k3s2
@@ -1095,10 +1121,12 @@ sync:
         - v1.25.9-rke2r1
         - v1.26.10-rke2r2
         - v1.26.11-rke2r1
+        - v1.26.13-rke2r1
         - v1.26.5-rke2r1
         - v1.26.6-rke2r1
         - v1.26.7-rke2r1
         - v1.26.8-rke2r1
+        - v1.27.10-rke2r1
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/44209

This also includes Jan 1.26 patch.