### PR TITLE
Validate helm chart repo in CI for rke2 charts

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1640,7 +1640,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.15.100
       rancher-vsphere-csi:
-        repo: rancher-charts
+        repo: rancher-rke2-charts
         version: 3.0.1-rancher101
       rke2-calico:
         repo: rancher-rke2-charts
@@ -1785,7 +1785,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.15.100
       rancher-vsphere-csi:
-        repo: rancher-charts
+        repo: rancher-rke2-charts
         version: 3.0.1-rancher101
       rke2-calico:
         repo: rancher-rke2-charts

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -266,19 +266,22 @@ func validateRKE2Charts(release map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
-		var chartIndex string
-		var otherChartIndex string
-		if repo == "rancher-charts" {
-			chartIndex = "https://charts.rancher.io"
-			otherChartIndex = "https://github.com/rancher/charts/"
-		} else if repo == "rancher-rke2-charts" {
-			chartIndex = "https://rke2-charts.rancher.io"
-		} else {
-			chartIndex = fmt.Sprintf("https://%s", repo)
+		var isValidRepo bool
+		const (
+			rancherChart    = "https://charts.rancher.io"
+			oldRancherChart = "https://github.com/rancher/charts/"
+			rke2Chart       = "https://rke2-charts.rancher.io"
+		)
+		switch repo {
+		case "rancher-charts":
+			isValidRepo = strings.HasPrefix(chartURL, rancherChart) || strings.HasPrefix(chartURL, oldRancherChart)
+		case "rancher-rke2-charts":
+			isValidRepo = strings.HasPrefix(chartURL, rke2Chart)
+		default:
+			isValidRepo = strings.HasPrefix(chartURL, fmt.Sprintf("https://%s", repo))
 		}
 		expectedChartTarball := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
-		if !strings.Contains(chartURL, expectedChartTarball) ||
-			!(strings.HasPrefix(chartURL, chartIndex) || strings.HasPrefix(chartURL, otherChartIndex)) {
+		if !strings.Contains(chartURL, expectedChartTarball) || !isValidRepo {
 			return fmt.Errorf("unexpected chart URL for %s/%s:%s: %s", repo, chartName, chartVersion, chartURL)
 		}
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -17,6 +17,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	rancherChart    = "https://charts.rancher.io"
+	oldRancherChart = "https://github.com/rancher/charts"
+	rke2Chart       = "https://rke2-charts.rancher.io"
+)
+
 var (
 	releaseDataURL    = "https://releases.rancher.com/kontainer-driver-metadata/%s/data.json"
 	releaseRegSyncURL = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/%s/regsync.yaml"
@@ -267,11 +273,6 @@ func validateRKE2Charts(release map[string]interface{}) error {
 			return err
 		}
 		var isValidRepo bool
-		const (
-			rancherChart    = "https://charts.rancher.io"
-			oldRancherChart = "https://github.com/rancher/charts/"
-			rke2Chart       = "https://rke2-charts.rancher.io"
-		)
 		switch repo {
 		case "rancher-charts":
 			isValidRepo = strings.HasPrefix(chartURL, rancherChart) || strings.HasPrefix(chartURL, oldRancherChart)

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -278,7 +278,7 @@ func validateRKE2Charts(release map[string]interface{}) error {
 		case "rancher-rke2-charts":
 			isValidRepo = strings.HasPrefix(chartURL, rke2Chart)
 		default:
-			isValidRepo = strings.HasPrefix(chartURL, fmt.Sprintf("https://%s", repo))
+			isValidRepo = strings.HasPrefix(chartURL, "https://"+repo)
 		}
 		expectedChartTarball := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
 		if !strings.Contains(chartURL, expectedChartTarball) || !isValidRepo {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -266,8 +266,19 @@ func validateRKE2Charts(release map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
+		var chartIndex string
+		var otherChartIndex string
+		if repo == "rancher-charts" {
+			chartIndex = "https://charts.rancher.io"
+			otherChartIndex = "https://github.com/rancher/charts/"
+		} else if repo == "rancher-rke2-charts" {
+			chartIndex = "https://rke2-charts.rancher.io"
+		} else {
+			chartIndex = fmt.Sprintf("https://%s", repo)
+		}
 		expectedChartTarball := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
-		if !strings.Contains(chartURL, expectedChartTarball) {
+		if !strings.Contains(chartURL, expectedChartTarball) ||
+			!(strings.HasPrefix(chartURL, chartIndex) || strings.HasPrefix(chartURL, otherChartIndex)) {
 			return fmt.Errorf("unexpected chart URL for %s/%s:%s: %s", repo, chartName, chartVersion, chartURL)
 		}
 	}


### PR DESCRIPTION
This will help to prevent us accidentally using the wrong repo value in the helm charts, as sometimes charts are pulled from `rancher-charts` and other times they use `rancher-rke2-charts`, which have separate helm chart repositories.

Some example failure messages from these changes will look like the following:
```
time="2024-03-21T19:54:23Z" level=fatal msg="failed to validte the KDM data for the release [release-v2.8]: failed to validate the distro [RKE2]: failed to validate RKE2 charts: unexpected chart URL for rancher-charts/rke2-cilium:1.9.809: https://rke2-charts.rancher.io/assets/rke2-cilium/rke2-cilium-1.9.809.tgz"

time="2024-03-21T19:32:42Z" level=fatal msg="failed to validte the KDM data for the release [release-v2.8]: failed to validate the distro [RKE2]: failed to validate RKE2 charts: unexpected chart URL for rancher-rke2-charts/rancher-vsphere-csi:100.0.0: https://github.com/rancher/charts/blob/a1f9fea117dbe1aca21337a1d3b4a3ba2e3d93fd/assets/rancher-vsphere-csi/rancher-vsphere-csi-100.0.0.tgz?raw=true"
```

This also located the root cause for the initial report of https://github.com/rancher/rancher/issues/44754 and fixes that retroactively.