### PR TITLE
[2.7] bump bci/golang tag to 1.21 instead of a specific patch tag

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.7-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.21-2.2.25
+FROM registry.suse.com/bci/golang:1.21
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher


### PR DESCRIPTION
bump bci/golang tag to 1.21 instead of a specific patch tag

this is a follow-up PR for https://github.com/rancher/kontainer-driver-metadata/pull/1359