### PR TITLE
[Backport v2.7] Validate helm chart repo in CI for rke2 charts

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1645,7 +1645,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.15.100
       rancher-vsphere-csi:
-        repo: rancher-charts
+        repo: rancher-rke2-charts
         version: 3.0.1-rancher101
       rke2-calico:
         repo: rancher-rke2-charts
@@ -1820,7 +1820,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.15.100
       rancher-vsphere-csi:
-        repo: rancher-charts
+        repo: rancher-rke2-charts
         version: 3.0.1-rancher101
       rke2-calico:
         repo: rancher-rke2-charts

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -17,6 +17,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	rancherChart    = "https://charts.rancher.io"
+	oldRancherChart = "https://github.com/rancher/charts"
+	rke2Chart       = "https://rke2-charts.rancher.io"
+)
+
 var (
 	releaseDataURL    = "https://releases.rancher.com/kontainer-driver-metadata/%s/data.json"
 	releaseRegSyncURL = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/%s/regsync.yaml"
@@ -267,8 +273,17 @@ func validateRKE2Charts(release map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
+		var isValidRepo bool
+		switch repo {
+		case "rancher-charts":
+			isValidRepo = strings.HasPrefix(chartURL, rancherChart) || strings.HasPrefix(chartURL, oldRancherChart)
+		case "rancher-rke2-charts":
+			isValidRepo = strings.HasPrefix(chartURL, rke2Chart)
+		default:
+			isValidRepo = strings.HasPrefix(chartURL, "https://"+repo)
+		}
 		expectedChartTarball := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
-		if !strings.Contains(chartURL, expectedChartTarball) {
+		if !strings.Contains(chartURL, expectedChartTarball) || !isValidRepo {
 			return fmt.Errorf("unexpected chart URL for %s/%s:%s: %s", repo, chartName, chartVersion, chartURL)
 		}
 	}


### PR DESCRIPTION
Backport for: https://github.com/rancher/kontainer-driver-metadata/pull/1363