### PR TITLE
[dev-v2.8] updated default rke version to v1.28.9

### DIFF
--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -64,7 +64,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.28.8-rancher1-1",
+		"default": "v1.28.9-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/45041