### PR TITLE
[SURE-8459]fix: remove system-default-registry flag from k3s and rke2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -120,8 +120,6 @@ releases:
         type: bool
       audit-policy-file:
         type: string
-      system-default-registry:
-        type: string
       protect-kernel-defaults:
         type: boolean
         default: false

--- a/channels.yaml
+++ b/channels.yaml
@@ -165,8 +165,6 @@ releases:
     serverArgs: *serverArgs-v2
     agentArgs: &agentArgs-v2
       <<: *agentArgs-v1
-      system-default-registry:
-        type: string
   - version: v1.21.10+k3s1
     minChannelServerVersion: v2.6.3-alpha1
     maxChannelServerVersion: v2.6.4


### PR DESCRIPTION
The `--system-default-registry` flag was removed from the rke2/k3s agent in this [PR](https://github.com/rancher/rke2/pull/971). However, it is still part of KDM, which is causing issues as noted in [this issue](https://github.com/rancher/rancher/issues/45607).