### PR TITLE
Revert 1.25 and 1.26 support removal

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1375,7 +1375,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.25.13+rke2r1
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v1-25-13-rke2r1
       <<: *serverArgs-v1-24-2-rke2r1
       tls-san-security:
@@ -1398,7 +1398,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.25.15+rke2r2
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v1-25-15-rke2r2
       <<: *serverArgs-v1-25-13-rke2r1
       kube-cloud-controller-manager-arg:
@@ -1437,7 +1437,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.25.16+rke2r1
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-25-15-rke2r2
     agentArgs: *agentArgs-v1-25-15-rke2r2
     charts: &charts-v1-25-16-rke2r1
@@ -1529,7 +1529,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.8+rke2r1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v1-26-8-rke2r1
       <<: *serverArgs-v1-24-2-rke2r1
       tls-san-security:
@@ -1552,7 +1552,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.10+rke2r2
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v1-26-10-rke2r2
       <<: *serverArgs-v1-26-8-rke2r1
       kube-cloud-controller-manager-arg:
@@ -1584,7 +1584,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.11+rke2r1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-26-10-rke2r2
     agentArgs: *agentArgs-v1-25-15-rke2r2
     charts: &charts-v1-26-11-rke2r1
@@ -1604,7 +1604,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.13+rke2r1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-26-10-rke2r2
     agentArgs: *agentArgs-v1-25-15-rke2r2
     charts: &charts-v1-26-13-rke2r1
@@ -1621,7 +1621,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.14+rke2r1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v1-26-14-rke2r1
       <<: *serverArgs-v1-26-10-rke2r2
       cni:
@@ -1668,7 +1668,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.15+rke2r1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-26-14-rke2r1
     agentArgs: *agentArgs-v1-25-15-rke2r2
     charts: &charts-v1-26-15-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -445,19 +445,19 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.25.13+k3s1
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.25.15+k3s2
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.25.16+k3s4
     minChannelServerVersion: v2.7.2-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: &agentArgs-v4
       <<: *agentArgs-v3
@@ -484,25 +484,25 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.8+k3s1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.26.10+k3s2
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v3
     featureVersions: *featureVersions-v1
   - version: v1.26.11+k3s2
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v6
     agentArgs: *agentArgs-v4
     featureVersions: *featureVersions-v1
   - version: v1.26.13+k3s2
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: &serverArgs-v7
       <<: *serverArgs-v6
       embedded-registry:
@@ -516,13 +516,13 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.26.14+k3s1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v7
     agentArgs: *agentArgs-v5
     featureVersions: *featureVersions-v1
   - version: v1.26.15+k3s1
     minChannelServerVersion: v2.7.5-alpha1
-    maxChannelServerVersion: v2.8.99
+    maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v7
     agentArgs: *agentArgs-v5
     featureVersions: *featureVersions-v1

--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -666,14 +666,10 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.25": {
 			MinRancherVersion: "2.7.2-patch0",
 			MinRKEVersion:     "1.4.0-rc0",
-			MaxRancherVersion: "2.8.99",
-			MaxRKEVersion:     "1.5.99",
 		},
 		"v1.26": {
 			MinRancherVersion: "2.7.5-patch0",
 			MinRKEVersion:     "1.4.0-rc0",
-			MaxRancherVersion: "2.8.99",
-			MaxRKEVersion:     "1.5.99",
 		},
 		"v1.27": {
 			MinRancherVersion: "2.8.0-patch0",


### PR DESCRIPTION
this is needed to make the CI pass for rancher 1.30 support PR
since there are some python test cases which still runs on v1.25 kubernetes cluster and because of that CI is failing ref: https://drone-pr.rancher.io/rancher/rancher/40366/7/2
