### PR TITLE
[2.9] unset the timeout-minute in the step mirror-image

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -35,7 +35,6 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     needs: validate
     container: 
       image: rancher/dapper:v0.6.0


### PR DESCRIPTION
[The step mirror-image](https://github.com/rancher/kontainer-driver-metadata/actions/runs/9995157447/job/27641259987) fails due to hitting the timeout limit. 
The actual time it takes to finish can vary based on the number of images to be mirrored, so unsettling the `timeout-minute`. 