### PR TITLE
[2.8] unset the timeout-minute in the step mirror-image

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -35,7 +35,6 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     needs: validate
     container: 
       image: rancher/dapper:v0.6.0


### PR DESCRIPTION
backport of https://github.com/rancher/kontainer-driver-metadata/pull/1444