### PR TITLE
[v2.10] Add Debug Arg

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -159,6 +159,8 @@ releases:
         type: array
       cloud-controller-manager-extra-env:
         type: array
+      debug:
+        type: bool
     charts: &charts-v1-21-4-rke2r2
       rke2-cilium:
         repo: rancher-rke2-charts

--- a/channels.yaml
+++ b/channels.yaml
@@ -131,6 +131,8 @@ releases:
         default: false
       resolv-conf:
         type: string
+      debug:
+        type: bool
   - version: v1.21.5+k3s1
     minChannelServerVersion: v2.6.0-alpha1
     maxChannelServerVersion: v2.6.4


### PR DESCRIPTION
Adds debug argument for k3s and rke2. This was missing, so to enabling debug you had to manually modify or add another config file on downstream clusters.