### PR TITLE
[v2.9] remove bird live from canal v3.28.1 liveness check

### DIFF
--- a/pkg/rke/templates/canal_v3.28.1.go
+++ b/pkg/rke/templates/canal_v3.28.1.go
@@ -8,7 +8,6 @@ Upstream Changelog:
 `metadataAddr` and `selector` properties description updated.
 - added property `debugHost`, `debugPort`, `debugSimulateCalcGraphHangAfter` and `endpointStatusPathPrefix`
 - added `type: DirectoryOrCreate` in calico-node DaemonSet
-- added `-bird-live` command in livenessProbe of canal Daemonset
 - whitespace fixes
 Rancher Changelog:
 - No new Rancher specific changes, same as CanalTemplateV3_26_1
@@ -4959,7 +4958,6 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
-              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6


### PR DESCRIPTION
**Problem:** 
`bird-live` and `bird-ready` checks are supposed to be only for calico. No CI checks failed as pods are running but they continuously restart. 
https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.9/pkg/rke/templates/canal_v3.28.1.go#L4962 

Calico v3.28.1 has them correctly: 
https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.9/pkg/rke/templates/calico_v3.28.1.go#L5026 
https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.9/pkg/rke/templates/calico_v3.28.1.go#L5036 

Also the new template for calico v3.27.4 has only `felix-live` check as expected: 
https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.9/pkg/rke/templates/canal_v3.27.4.go#L4936 

--- 

**Issue:** https://github.com/rancher/rancher/issues/47139 