### PR TITLE
[v2.10] set default k8s to v1.31.x 

### DIFF
--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -57,7 +57,7 @@ func loadRancherDefaultK8sVersions() map[string]string {
 		"2.8.3":        "v1.28.x",
 		"2.9.0":        "v1.30.x",
 		// rancher will use default if its version is absent
-		"default": "v1.30.x",
+		"default": "v1.31.x",
 	}
 }
 
@@ -65,7 +65,7 @@ func loadRKEDefaultK8sVersions() map[string]string {
 	return map[string]string{
 		"0.3": "v1.16.3-rancher1-1",
 		// rke will use default if its version is absent
-		"default": "v1.30.5-rancher1-1",
+		"default": "v1.31.1-rancher1-1",
 	}
 }
 


### PR DESCRIPTION
### Updates

- set 1.31.1 as default k8s version

### Related

- https://github.com/rancher/rancher/issues/46197