### PR TITLE
Add 1.31 support for rke2 and k3s

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -20,6 +20,8 @@ appDefaults:
         defaultVersion: '1.28.x'
       - appVersion: '>= 2.9.0-0 < 2.9.100-0'
         defaultVersion: '1.30.x'
+      - appVersion: '>= 2.10.0-0 < 2.10.100-0'
+        defaultVersion: '1.31.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -20,6 +20,8 @@ appDefaults:
         defaultVersion: '1.28.x'
       - appVersion: '>= 2.9.0-0 < 2.9.100-0'
         defaultVersion: '1.30.x'
+      - appVersion: '>= 2.10.0-0 < 2.10.100-0'
+        defaultVersion: '1.31.x'  
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1


### PR DESCRIPTION
### Updates

- Add support for 1.31 in RKE2 and K3s, as 1.31 entry was missing (earlier showing as experimental)
![image](https://github.com/user-attachments/assets/08e9e46d-c7fd-44fe-907a-7aabdf7d6baf)

### Related

- https://github.com/rancher/rancher/issues/46197
