### PR TITLE
[v2.10] Remove k8s 1.27 support

### DIFF
--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -678,6 +678,8 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.27": {
 			MinRancherVersion: "2.8.0-patch0",
 			MinRKEVersion:     "1.5.0-rc0",
+			MaxRancherVersion: "2.9.99",
+			MaxRKEVersion:     "1.6.99",
 		},
 		"v1.28": {
 			MinRancherVersion: "2.8.3-patch0",


### PR DESCRIPTION
## Updates

### RKE2
- v1.27 latest rke2  v1.27.16+rke2r1 has already the maxRancherVersion as v2.9.99 [ref](https://github.com/rancher/kontainer-driver-metadata/blob/bce54ac7114e22a969e13c5a2fea0c089b3a6e1d/channels-rke2.yaml#L1977)

### k3s
- v1.27 latest k3s v1.27.16+k3s1 has already the maxRancherVersion as v2.9.99 [ref](https://github.com/chiukapoor/kontainer-driver-metadata/blob/f6fe4a9c0ad95a55002237b8ed76cc487570199b/channels.yaml#L602)

### RKE1
- added max rancher and rke versions (2.9.99 and 1.6.99 respecrively) constraints for k8s v1.27

## Issue
- https://github.com/rancher/rancher/issues/47591