### PR TITLE
[v2.7] September Patch Release

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.7-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher
@@ -61,7 +61,7 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV GOLANGCI_LINT v1.56.2
+ENV GOLANGCI_LINT v1.57.2
 
 RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1977,3 +1977,28 @@ releases:
         repo: rancher-rke2-charts
         version: 3.3.0-rancher100
     featureVersions: *featureVersions-v1
+  - version: v1.27.16+rke2r2
+    minChannelServerVersion: v2.7.11-alpha1
+    maxChannelServerVersion: v2.8.99
+    serverArgs: &serverArgs-v1-27-16-rke2r2
+      <<: *serverArgs-v1-27-16-rke2r1
+    agentArgs: &agentArgs-v1-27-16-rke2r2
+      <<: *agentArgs-v1-27-16-rke2r1
+    charts: &charts-v1-27-16-rke2r2
+      <<: *charts-v1-27-16-rke2r1
+      rke2-cilium:
+        repo: rancher-rke2-charts
+        version: 1.16.000
+      rke2-canal:
+        repo: rancher-rke2-charts
+        version: v3.28.1-build2024080600
+      rke2-ingress-nginx:
+        repo: rancher-rke2-charts
+        version: 4.10.401
+      rke2-flannel:
+        repo: rancher-rke2-charts
+        version: v0.25.501
+      harvester-csi-driver:
+        repo: rancher-rke2-charts
+        version: 0.1.1800
+    featureVersions: *featureVersions-v1

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -1955,3 +1955,25 @@ releases:
         repo: rancher-rke2-charts
         version: 0.2.400
     featureVersions: *featureVersions-v1
+  - version: v1.27.16+rke2r1
+    minChannelServerVersion: v2.7.11-alpha1
+    maxChannelServerVersion: v2.8.99
+    serverArgs: &serverArgs-v1-27-16-rke2r1
+      <<: *serverArgs-v1-27-15-rke2r1
+    agentArgs: &agentArgs-v1-27-16-rke2r1
+      <<: *agentArgs-v1-27-15-rke2r1
+    charts: &charts-v1-27-16-rke2r1
+      <<: *charts-v1-27-15-rke2r1
+      rke2-ingress-nginx:
+        repo: rancher-rke2-charts
+        version: 4.10.102
+      rke2-multus:
+        repo: rancher-rke2-charts
+        version: v4.0.206
+      rancher-vsphere-cpi:
+        repo: rancher-rke2-charts
+        version: 1.8.000
+      rancher-vsphere-csi:
+        repo: rancher-rke2-charts
+        version: 3.3.0-rancher100
+    featureVersions: *featureVersions-v1

--- a/channels.yaml
+++ b/channels.yaml
@@ -589,3 +589,9 @@ releases:
       bind-address:
         type: string
     featureVersions: *featureVersions-v1
+  - version: v1.27.16+k3s1
+    minChannelServerVersion: v2.7.11-alpha1
+    maxChannelServerVersion: v2.7.99
+    serverArgs: *serverArgs-v9
+    agentArgs: *agentArgs-v6
+    featureVersions: *featureVersions-v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/kontainer-driver-metadata
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -52,6 +52,7 @@ sync:
         - v3.27.2-build20240308
         - v3.27.3-build20240423
         - v3.28.0-build20240625
+        - v3.28.1-build20240806
   - source: docker.io/rancher/hardened-cluster-autoscaler
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-cluster-autoscaler'
     type: repository
@@ -75,6 +76,7 @@ sync:
         - v1.4.0-build20240122
         - v1.4.1-build20240325
         - v1.4.1-build20240430
+        - v1.5.1-build20240805
   - source: docker.io/rancher/hardened-coredns
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-coredns'
     type: repository
@@ -127,6 +129,7 @@ sync:
         - v0.24.3-build20240307
         - v0.25.1-build20240423
         - v0.25.4-build20240610
+        - v0.25.5-build20240801
   - source: docker.io/rancher/hardened-ib-sriov-cni
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-ib-sriov-cni'
     type: repository
@@ -195,6 +198,7 @@ sync:
         - v1.27.14-rke2r1-build20240515
         - v1.27.15-rke2r1-build20240619
         - v1.27.16-rke2r1-build20240717
+        - v1.27.16-rke2r2-build20240819
         - v1.27.5-rke2r1-build20230824
         - v1.27.7-rke2r2-build20231102
         - v1.27.8-rke2r1-build20231115
@@ -310,6 +314,7 @@ sync:
         - v0.1.4
         - v0.1.5
         - v0.1.6
+        - v0.1.7
   - source: docker.io/rancher/hyperkube
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hyperkube'
     type: repository
@@ -434,6 +439,7 @@ sync:
         - v0.4.4
         - v0.4.5
         - v0.4.7
+        - v0.4.9
   - source: docker.io/rancher/local-path-provisioner
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/local-path-provisioner'
     type: repository
@@ -613,6 +619,7 @@ sync:
         - v0.1.12
         - v0.1.8
         - v0.1.9
+        - v0.2.0
   - source: docker.io/rancher/mirrored-cilium-cilium
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-cilium'
     type: repository
@@ -631,6 +638,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-cilium-envoy
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-cilium-envoy'
     type: repository
@@ -642,6 +650,7 @@ sync:
         - v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
         - v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
         - v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
+        - v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
   - source: docker.io/rancher/mirrored-cilium-cilium-etcd-operator
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-cilium-etcd-operator'
     type: repository
@@ -663,6 +672,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-hubble-relay
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-hubble-relay'
     type: repository
@@ -678,6 +688,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-hubble-ui
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-hubble-ui'
     type: repository
@@ -688,6 +699,7 @@ sync:
         - v0.12.0
         - v0.12.1
         - v0.13.0
+        - v0.13.1
         - v0.9.2
   - source: docker.io/rancher/mirrored-cilium-hubble-ui-backend
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-hubble-ui-backend'
@@ -699,6 +711,7 @@ sync:
         - v0.12.0
         - v0.12.1
         - v0.13.0
+        - v0.13.1
         - v0.9.2
   - source: docker.io/rancher/mirrored-cilium-kvstoremesh
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-kvstoremesh'
@@ -726,6 +739,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-operator-azure
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-operator-azure'
     type: repository
@@ -744,6 +758,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-operator-generic
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-operator-generic'
     type: repository
@@ -762,6 +777,7 @@ sync:
         - v1.15.1
         - v1.15.4
         - v1.15.5
+        - v1.16.0
   - source: docker.io/rancher/mirrored-cilium-startup-script
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cilium-startup-script'
     type: repository
@@ -866,6 +882,7 @@ sync:
     tags:
       allow:
         - v1.1.1
+        - v1.4.1
         - v20230312-helm-chart-4.5.2-28-g66a760794
         - v20231011-8b53cabe0
   - source: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny
@@ -1065,6 +1082,7 @@ sync:
         - nginx-1.9.4-rancher1
         - nginx-1.9.6-hardened1
         - v1.10.1-hardened1
+        - v1.10.4-hardened2
   - source: docker.io/rancher/pause
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/pause'
     type: repository
@@ -1185,6 +1203,8 @@ sync:
         - v1.27.15-rke2r1-windows-amd64
         - v1.27.16-rke2r1
         - v1.27.16-rke2r1-windows-amd64
+        - v1.27.16-rke2r2
+        - v1.27.16-rke2r2-windows-amd64
         - v1.27.5-rke2r1
         - v1.27.5-rke2r1-windows-amd64
         - v1.27.7-rke2r2
@@ -1237,6 +1257,7 @@ sync:
         - v1.27.14-rke2r1
         - v1.27.15-rke2r1
         - v1.27.16-rke2r1
+        - v1.27.16-rke2r2
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1
@@ -1335,6 +1356,7 @@ sync:
         - v1.27.14-rke2r1
         - v1.27.15-rke2r1
         - v1.27.16-rke2r1
+        - v1.27.16-rke2r2
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -404,6 +404,7 @@ sync:
         - v1.27.13-k3s1
         - v1.27.14-k3s1
         - v1.27.15-k3s2
+        - v1.27.16-k3s1
         - v1.27.5-k3s1
         - v1.27.7-k3s2
         - v1.27.8-k3s2
@@ -441,6 +442,7 @@ sync:
         - v0.0.24
         - v0.0.26
         - v0.0.27
+        - v0.0.28
   - source: docker.io/rancher/longhornio-csi-attacher
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/longhornio-csi-attacher'
     type: repository
@@ -1270,6 +1272,7 @@ sync:
         - v1.27.13-k3s1
         - v1.27.14-k3s1
         - v1.27.15-k3s2
+        - v1.27.16-k3s1
         - v1.27.5-k3s1
         - v1.27.7-k3s2
         - v1.27.8-k3s2

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -194,6 +194,7 @@ sync:
         - v1.27.13-rke2r1-build20240416
         - v1.27.14-rke2r1-build20240515
         - v1.27.15-rke2r1-build20240619
+        - v1.27.16-rke2r1-build20240717
         - v1.27.5-rke2r1-build20230824
         - v1.27.7-rke2r2-build20231102
         - v1.27.8-rke2r1-build20231115
@@ -211,6 +212,7 @@ sync:
         - v4.0.2-build20231009
         - v4.0.2-build20240208
         - v4.0.2-build20240418
+        - v4.0.2-build20240612
   - source: docker.io/rancher/hardened-node-feature-discovery
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-node-feature-discovery'
     type: repository
@@ -795,6 +797,7 @@ sync:
         - v2.7.0
         - v3.0.1
         - v3.1.2
+        - v3.3.0
   - source: docker.io/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer'
     type: repository
@@ -807,6 +810,7 @@ sync:
         - v2.7.0
         - v3.0.1
         - v3.1.2
+        - v3.3.0
   - source: docker.io/rancher/mirrored-cluster-proportional-autoscaler
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cluster-proportional-autoscaler'
     type: repository
@@ -981,11 +985,13 @@ sync:
         - v3.4.0
         - v4.2.0
         - v4.3.0
+        - v4.5.1
   - source: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-sig-storage-csi-node-driver-registrar'
     type: repository
     tags:
       allow:
+        - v2.10.1
         - v2.5.0
         - v2.5.1
         - v2.7.0
@@ -999,11 +1005,13 @@ sync:
         - v3.2.1
         - v3.4.0
         - v3.5.0
+        - v4.0.1
   - source: docker.io/rancher/mirrored-sig-storage-csi-resizer
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-sig-storage-csi-resizer'
     type: repository
     tags:
       allow:
+        - v1.10.1
         - v1.4.0
         - v1.7.0
         - v1.8.0
@@ -1013,12 +1021,14 @@ sync:
     tags:
       allow:
         - v6.2.1
+        - v7.0.2
   - source: docker.io/rancher/mirrored-sig-storage-livenessprobe
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-sig-storage-livenessprobe'
     type: repository
     tags:
       allow:
         - v2.10.0
+        - v2.12.0
         - v2.6.0
         - v2.7.0
         - v2.9.0
@@ -1173,6 +1183,8 @@ sync:
         - v1.27.14-rke2r1-windows-amd64
         - v1.27.15-rke2r1
         - v1.27.15-rke2r1-windows-amd64
+        - v1.27.16-rke2r1
+        - v1.27.16-rke2r1-windows-amd64
         - v1.27.5-rke2r1
         - v1.27.5-rke2r1-windows-amd64
         - v1.27.7-rke2r2
@@ -1224,6 +1236,7 @@ sync:
         - v1.27.13-rke2r1
         - v1.27.14-rke2r1
         - v1.27.15-rke2r1
+        - v1.27.16-rke2r1
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1
@@ -1321,6 +1334,7 @@ sync:
         - v1.27.13-rke2r1
         - v1.27.14-rke2r1
         - v1.27.15-rke2r1
+        - v1.27.16-rke2r1
         - v1.27.5-rke2r1
         - v1.27.7-rke2r2
         - v1.27.8-rke2r1


### PR DESCRIPTION
Note:
- the versions v1.27.16+rke2r1 / v1.27.16+rke2r2  have existed in the release/v2.7 branch, introduced by this PR https://github.com/rancher/kontainer-driver-metadata/pull/1448, GH shows them in the PR because of the git history difference. 
https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.7/channels-rke2.yaml#L1958-L2004