### PR TITLE
[v2.7] bump go to 1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.7-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher
@@ -61,7 +61,7 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV GOLANGCI_LINT v1.56.2
+ENV GOLANGCI_LINT v1.57.2
 
 RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/kontainer-driver-metadata
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e


### PR DESCRIPTION
To fix workflow failure: 
https://github.com/rancher/kontainer-driver-metadata/actions/runs/11411914981/job/31757018106?pr=1525
```
#11 [stage-1 12/14] RUN go install golang.org/x/tools/cmd/goimports@latest
#11 0.207 go: downloading golang.org/x/tools v0.26.0
#11 0.388 go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.26.0 requires go >= 1.22.0 (running go 1.21.12; GOTOOLCHAIN=local)
#11 ERROR: process "/bin/sh -c go install golang.org/x/tools/cmd/goimports@latest" did not complete successfully: exit code: 1
```