### PR TITLE
[dev.v2.10] Mirror missing images only

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -73,7 +73,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \
-        curl -sL https://github.com/regclient/regclient/releases/download/v0.4.8/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
+        curl -sL https://github.com/regclient/regclient/releases/download/v0.7.1/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
 ENV YQ_VERSION v4.41.1

--- a/scripts/mirror-images
+++ b/scripts/mirror-images
@@ -4,4 +4,4 @@ set -e
 cd $(dirname $0)/..
 
 echo Regsync mirroring images
-regsync once --config ./regsync.yaml
+regsync once --missing --config ./regsync.yaml


### PR DESCRIPTION
Some images in the rancher registry may have different digests than their counterparts in docker hub. This change ensures images with the same tag but different digests will not be overwritten.