### PR TITLE
[2.10] Use v2.10 images when running provisioning tests

### DIFF
--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         dist: [rke2, k3s]
-        k8s-minor: [27, 28, 29, 30]
+        k8s-minor: [27, 28, 29, 30, 31]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
     steps:
       - name: Force Install GIT latest

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG RANCHER_VERSION=v2.9-head
+ARG RANCHER_VERSION=v2.10-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 

--- a/scripts/fetch-provisioning-tests
+++ b/scripts/fetch-provisioning-tests
@@ -12,7 +12,7 @@ TMP_DIR=$(mktemp -d)
 pushd "$TMP_DIR"
 
 IMAGE_REPO=${IMAGE_REPO:-rancher/rancher}
-IMAGE_TAG=${IMAGE_TAG:-v2.9-head}
+IMAGE_TAG=${IMAGE_TAG:-v2.10-head}
 IMAGE=${IMAGE:-$IMAGE_REPO:$IMAGE_TAG}
 
 # Inspect image, get server version and extract rancher commit 
@@ -29,7 +29,7 @@ mkdir -p rancher
 # Although using the commit so the image matches the source code, use the default branch associated with that release line
 # Git clones must have a branch, and the release branch is likely to contain the commit anyway
 GIT_URL=${GIT_URL:-https://github.com/rancher/rancher.git}
-GIT_BRANCH=${GIT_BRANCH:-release/v2.9}
+GIT_BRANCH=${GIT_BRANCH:-release/v2.10}
 
 git clone --depth 1 -b $GIT_BRANCH $GIT_URL ./rancher
 


### PR DESCRIPTION
Updating `Dockerfile.dapper` and `fetch-provisioning-tests` to pull v2.10 images, changing provisioning test range from 1.27 - 1.31