### PR TITLE
[dev-v2.10] removed 27 minor version from provisioning-tests

### DIFF
--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         dist: [rke2, k3s]
-        k8s-minor: [27, 28, 29, 30, 31]
+        k8s-minor: [28, 29, 30, 31]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
     steps:
       - name: Force Install GIT latest


### PR DESCRIPTION
- removed k8s minor version **27** from provisioning tests for dev-v2.10 since minimum supported version in rancher v2.10 is 1.28