### PR TITLE
[v2.11] update version information for v2.11.0

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -20,7 +20,7 @@ appDefaults:
         defaultVersion: '1.28.x'
       - appVersion: '>= 2.9.0-0 < 2.9.100-0'
         defaultVersion: '1.30.x'
-      - appVersion: '>= 2.10.0-0 < 2.10.100-0'
+      - appVersion: '>= 2.10.0-0 < 2.11.100-0'
         defaultVersion: '1.31.x'
 releases:
   - version: v1.19.16+rke2r1
@@ -2766,7 +2766,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.10.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-9-rke2r1
@@ -3015,7 +3015,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.5+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.10.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-5-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -20,7 +20,7 @@ appDefaults:
         defaultVersion: '1.28.x'
       - appVersion: '>= 2.9.0-0 < 2.9.100-0'
         defaultVersion: '1.30.x'
-      - appVersion: '>= 2.10.0-0 < 2.10.100-0'
+      - appVersion: '>= 2.10.0-0 < 2.11.100-0'
         defaultVersion: '1.31.x'  
 releases:
   - version: v1.18.20+k3s1
@@ -772,7 +772,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.10.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
@@ -802,7 +802,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.5+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.10.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1

--- a/pkg/rke/k8s_version_info.go
+++ b/pkg/rke/k8s_version_info.go
@@ -684,10 +684,14 @@ func loadK8sVersionInfo() map[string]v3.K8sVersionInfo {
 		"v1.28": {
 			MinRancherVersion: "2.8.3-patch0",
 			MinRKEVersion:     "1.5.0-rc0",
+			MaxRancherVersion: "2.10.99",
+			MaxRKEVersion:     "1.7.99",
 		},
 		"v1.29": {
 			MinRancherVersion: "2.9.0-patch0",
 			MinRKEVersion:     "1.6.0-rc0",
+			MaxRancherVersion: "2.10.99",
+			MaxRKEVersion:     "1.7.99",
 		},
 		"v1.30": {
 			MinRancherVersion: "2.9.0-patch0",


### PR DESCRIPTION
Preparing versions for v2.11.0. v1.32 support will be introduced later. 

- `v1.30.9`
- `v1.31.5`

https://github.com/rancher/rancher/issues/48628 
https://github.com/rancher/rancher/issues/49033 