### PR TITLE
Update version in validate-ci to 2.10

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,4 +24,4 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Checking if released versions are not changed
-go run ./pkg/validation/validation.go release-v2.9
+go run ./pkg/validation/validation.go release-v2.10


### PR DESCRIPTION
Version was pointing to 2.9, since release-2.10 was not created when this was first updated. Changing it now.