### PR TITLE
Add v1 29 14

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2252,14 +2252,14 @@ releases:
     maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-28-8-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
-    charts: *charts-v1-28-8-rke2r1   
+    charts: *charts-v1-28-8-rke2r1
     featureVersions: *featureVersions-v1
   - version: v1.29.4+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
     serverArgs: *serverArgs-v1-28-9-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
-    charts: *charts-v1-28-9-rke2r1   
+    charts: *charts-v1-28-9-rke2r1
     featureVersions: *featureVersions-v1
   - version: v1.29.5+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
@@ -2525,6 +2525,41 @@ releases:
       rke2-runtimeclasses:
         repo: rancher-rke2-charts
         version: 0.1.000
+    featureVersions: *featureVersions-v1
+  - version: v1.29.14+rke2r1
+    minChannelServerVersion: v2.9.0-alpha1
+    maxChannelServerVersion: v2.10.99
+    serverArgs: *serverArgs-v1-28-9-rke2r1
+    agentArgs: *agentArgs-v1-28-8-rke2r1
+    charts: &charts-v1-29-14-rke2r1
+      <<: *charts-v1-29-13-rke2r1
+      rke2-multus:
+        repo: rancher-rke2-charts
+        version: v4.1.403
+      rke2-flannel:
+        repo: rancher-rke2-charts
+        version: v0.26.403
+      rancher-vsphere-csi:
+        repo: rancher-rke2-charts
+        version: 3.3.1-rancher900
+      rke2-cilium:
+        repo: rancher-rke2-charts
+        version: 1.17.000
+      rke2-calico:
+        repo: rancher-rke2-charts
+        version: v3.29.200
+      rke2-calico-crd:
+        repo: rancher-rke2-charts
+        version: v3.29.101
+      rke2-canal:
+        repo: rancher-rke2-charts
+        version: v3.29.2-build2025021800
+      harvester-csi-driver:
+        repo: rancher-rke2-charts
+        version: 0.1.2300
+      rke2-ingress-nginx:
+        repo: rancher-rke2-charts
+        version: 4.12.005
     featureVersions: *featureVersions-v1
   - version: v1.30.1+rke2r1
     minChannelServerVersion: v2.9.0-alpha1

--- a/channels.yaml
+++ b/channels.yaml
@@ -21,7 +21,7 @@ appDefaults:
       - appVersion: '>= 2.9.0-0 < 2.9.100-0'
         defaultVersion: '1.30.x'
       - appVersion: '>= 2.10.0-0 < 2.11.100-0'
-        defaultVersion: '1.31.x'  
+        defaultVersion: '1.31.x'
       - appVersion: '>= 2.11.0-0 < 2.12.100-0'
         defaultVersion: '1.32.x'
 releases:
@@ -719,6 +719,12 @@ releases:
         type: array
     featureVersions: *featureVersions-v1
   - version: v1.29.13+k3s1
+    minChannelServerVersion: v2.9.0-alpha1
+    maxChannelServerVersion: v2.10.99
+    serverArgs: *serverArgs-v9
+    agentArgs: *agentArgs-v7
+    featureVersions: *featureVersions-v1
+  - version: v1.29.14+k3s1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
     serverArgs: *serverArgs-v9

--- a/data/data.json
+++ b/data/data.json
@@ -32482,6 +32482,210 @@
    },
    {
     "agentArgs": {
+     "bind-address": {
+      "type": "string"
+     },
+     "debug": {
+      "type": "bool"
+     },
+     "default-runtime": {
+      "type": "string"
+     },
+     "disable-apiserver-lb": {
+      "type": "boolean"
+     },
+     "disable-default-registry-endpoint": {
+      "type": "boolean"
+     },
+     "docker": {
+      "default": false,
+      "type": "boolean"
+     },
+     "enable-pprof": {
+      "type": "boolean"
+     },
+     "flannel-conf": {
+      "type": "string"
+     },
+     "flannel-iface": {
+      "type": "string"
+     },
+     "kube-proxy-arg": {
+      "type": "array"
+     },
+     "kubelet-arg": {
+      "type": "array"
+     },
+     "node-external-dns": {
+      "type": "array"
+     },
+     "node-internal-dns": {
+      "type": "array"
+     },
+     "pause-image": {
+      "type": "string"
+     },
+     "protect-kernel-defaults": {
+      "default": false,
+      "type": "boolean"
+     },
+     "resolv-conf": {
+      "type": "string"
+     },
+     "selinux": {
+      "default": false,
+      "type": "boolean"
+     },
+     "snapshotter": {
+      "type": "string"
+     },
+     "system-default-registry": {
+      "type": "string"
+     },
+     "vpn-auth": {
+      "type": "string"
+     },
+     "vpn-auth-file": {
+      "type": "string"
+     }
+    },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
+    "maxChannelServerVersion": "v2.10.99",
+    "minChannelServerVersion": "v2.9.0-alpha1",
+    "serverArgs": {
+     "cluster-cidr": {
+      "type": "string"
+     },
+     "cluster-dns": {
+      "type": "string"
+     },
+     "cluster-domain": {
+      "type": "string"
+     },
+     "datastore-cafile": {
+      "type": "string"
+     },
+     "datastore-certfile": {
+      "type": "string"
+     },
+     "datastore-endpoint": {
+      "type": "string"
+     },
+     "datastore-keyfile": {
+      "type": "string"
+     },
+     "default-local-storage-path": {
+      "type": "string"
+     },
+     "disable": {
+      "options": [
+       "coredns",
+       "servicelb",
+       "traefik",
+       "local-storage",
+       "metrics-server"
+      ],
+      "type": "array"
+     },
+     "disable-apiserver": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-cloud-controller": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-controller-manager": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-etcd": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-kube-proxy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-network-policy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-scheduler": {
+      "default": false,
+      "type": "boolean"
+     },
+     "egress-selector-mode": {
+      "type": "string"
+     },
+     "embedded-registry": {
+      "type": "boolean"
+     },
+     "etcd-arg": {
+      "type": "array"
+     },
+     "etcd-expose-metrics": {
+      "default": false,
+      "type": "boolean"
+     },
+     "flannel-backend": {
+      "options": [
+       "none",
+       "vxlan",
+       "ipsec",
+       "host-gw",
+       "wireguard",
+       "wireguard-native"
+      ],
+      "type": "enum"
+     },
+     "helm-job-image": {
+      "type": "string"
+     },
+     "kine-tls": {
+      "type": "boolean"
+     },
+     "kube-apiserver-arg": {
+      "type": "array"
+     },
+     "kube-cloud-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-scheduler-arg": {
+      "type": "array"
+     },
+     "secrets-encryption": {
+      "default": false,
+      "type": "boolean"
+     },
+     "service-cidr": {
+      "type": "string"
+     },
+     "service-node-port-range": {
+      "type": "string"
+     },
+     "supervisor-metrics": {
+      "type": "boolean"
+     },
+     "tls-san": {
+      "type": "array"
+     },
+     "tls-san-security": {
+      "type": "boolean"
+     },
+     "write-kubeconfig-group": {
+      "type": "string"
+     }
+    },
+    "version": "v1.29.14+k3s1"
+   },
+   {
+    "agentArgs": {
      "debug": {
       "type": "bool"
      },
@@ -61204,6 +61408,307 @@
      }
     },
     "version": "v1.29.13+rke2r1"
+   },
+   {
+    "agentArgs": {
+     "audit-policy-file": {
+      "type": "string"
+     },
+     "cloud-controller-manager-extra-env": {
+      "type": "array"
+     },
+     "cloud-controller-manager-extra-mount": {
+      "type": "array"
+     },
+     "cloud-provider-config": {
+      "type": "string"
+     },
+     "cloud-provider-name": {
+      "default": null,
+      "nullable": true,
+      "options": [
+       "aws",
+       "azure",
+       "gcp",
+       "rancher-vsphere",
+       "harvester",
+       "external"
+      ],
+      "type": "enum"
+     },
+     "control-plane-resource-limits": {
+      "type": "string"
+     },
+     "control-plane-resource-requests": {
+      "type": "string"
+     },
+     "debug": {
+      "type": "bool"
+     },
+     "default-runtime": {
+      "type": "string"
+     },
+     "disable-default-registry-endpoint": {
+      "type": "boolean"
+     },
+     "etcd-extra-env": {
+      "type": "array"
+     },
+     "etcd-extra-mount": {
+      "type": "array"
+     },
+     "kube-apiserver-extra-env": {
+      "type": "array"
+     },
+     "kube-apiserver-extra-mount": {
+      "type": "array"
+     },
+     "kube-controller-manager-extra-env": {
+      "type": "array"
+     },
+     "kube-controller-manager-extra-mount": {
+      "type": "array"
+     },
+     "kube-proxy-arg": {
+      "type": "array"
+     },
+     "kube-proxy-extra-env": {
+      "type": "array"
+     },
+     "kube-proxy-extra-mount": {
+      "type": "array"
+     },
+     "kube-scheduler-extra-env": {
+      "type": "array"
+     },
+     "kube-scheduler-extra-mount": {
+      "type": "array"
+     },
+     "kubelet-arg": {
+      "type": "array"
+     },
+     "profile": {
+      "nullable": true,
+      "options": [
+       "cis",
+       "cis-1.23"
+      ],
+      "type": "enum"
+     },
+     "protect-kernel-defaults": {
+      "default": false,
+      "type": "boolean"
+     },
+     "resolv-conf": {
+      "type": "string"
+     },
+     "selinux": {
+      "type": "bool"
+     },
+     "system-default-registry": {
+      "type": "string"
+     }
+    },
+    "charts": {
+     "harvester-cloud-provider": {
+      "repo": "rancher-rke2-charts",
+      "version": "0.2.900"
+     },
+     "harvester-csi-driver": {
+      "repo": "rancher-rke2-charts",
+      "version": "0.1.2300"
+     },
+     "rancher-vsphere-cpi": {
+      "repo": "rancher-rke2-charts",
+      "version": "1.9.100"
+     },
+     "rancher-vsphere-csi": {
+      "repo": "rancher-rke2-charts",
+      "version": "3.3.1-rancher900"
+     },
+     "rke2-calico": {
+      "repo": "rancher-rke2-charts",
+      "version": "v3.29.200"
+     },
+     "rke2-calico-crd": {
+      "repo": "rancher-rke2-charts",
+      "version": "v3.29.101"
+     },
+     "rke2-canal": {
+      "repo": "rancher-rke2-charts",
+      "version": "v3.29.2-build2025021800"
+     },
+     "rke2-cilium": {
+      "repo": "rancher-rke2-charts",
+      "version": "1.17.000"
+     },
+     "rke2-coredns": {
+      "repo": "rancher-rke2-charts",
+      "version": "1.36.102"
+     },
+     "rke2-flannel": {
+      "repo": "rancher-rke2-charts",
+      "version": "v0.26.403"
+     },
+     "rke2-ingress-nginx": {
+      "repo": "rancher-rke2-charts",
+      "version": "4.12.005"
+     },
+     "rke2-metrics-server": {
+      "repo": "rancher-rke2-charts",
+      "version": "3.12.200"
+     },
+     "rke2-multus": {
+      "repo": "rancher-rke2-charts",
+      "version": "v4.1.403"
+     },
+     "rke2-runtimeclasses": {
+      "repo": "rancher-rke2-charts",
+      "version": "0.1.000"
+     },
+     "rke2-snapshot-controller": {
+      "repo": "rancher-rke2-charts",
+      "version": "4.0.002"
+     },
+     "rke2-snapshot-controller-crd": {
+      "repo": "rancher-rke2-charts",
+      "version": "4.0.002"
+     },
+     "rke2-snapshot-validation-webhook": {
+      "repo": "rancher-rke2-charts",
+      "version": "0.0.0"
+     }
+    },
+    "featureVersions": {
+     "encryption-key-rotation": "2.0.0"
+    },
+    "maxChannelServerVersion": "v2.10.99",
+    "minChannelServerVersion": "v2.9.0-alpha1",
+    "serverArgs": {
+     "audit-policy-file": {
+      "type": "string"
+     },
+     "cluster-cidr": {
+      "type": "string"
+     },
+     "cluster-dns": {
+      "type": "string"
+     },
+     "cluster-domain": {
+      "type": "string"
+     },
+     "cni": {
+      "default": "calico",
+      "options": [
+       "canal",
+       "cilium",
+       "calico",
+       "flannel",
+       "multus,canal",
+       "multus,cilium",
+       "multus,calico"
+      ],
+      "type": "array"
+     },
+     "container-runtime-endpoint": {
+      "type": "string"
+     },
+     "datastore-cafile": {
+      "type": "string"
+     },
+     "datastore-certfile": {
+      "type": "string"
+     },
+     "datastore-endpoint": {
+      "type": "string"
+     },
+     "datastore-keyfile": {
+      "type": "string"
+     },
+     "disable": {
+      "options": [
+       "rke2-coredns",
+       "rke2-ingress-nginx",
+       "rke2-metrics-server"
+      ],
+      "type": "array"
+     },
+     "disable-cloud-controller": {
+      "type": "bool"
+     },
+     "disable-kube-proxy": {
+      "default": false,
+      "type": "boolean"
+     },
+     "disable-scheduler": {
+      "type": "bool"
+     },
+     "egress-selector-mode": {
+      "type": "string"
+     },
+     "embedded-registry": {
+      "type": "boolean"
+     },
+     "etcd-arg": {
+      "type": "array"
+     },
+     "etcd-expose-metrics": {
+      "default": false,
+      "type": "boolean"
+     },
+     "etcd-image": {
+      "type": "string"
+     },
+     "kube-apiserver-arg": {
+      "type": "array"
+     },
+     "kube-apiserver-image": {
+      "type": "string"
+     },
+     "kube-cloud-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-controller-manager-arg": {
+      "type": "array"
+     },
+     "kube-controller-manager-image": {
+      "type": "string"
+     },
+     "kube-proxy-arg": {
+      "type": "array"
+     },
+     "kube-scheduler-arg": {
+      "type": "array"
+     },
+     "kube-scheduler-image": {
+      "type": "string"
+     },
+     "kubelet-path": {
+      "type": "string"
+     },
+     "pause-image": {
+      "type": "string"
+     },
+     "runtime-image": {
+      "type": "string"
+     },
+     "service-cidr": {
+      "type": "string"
+     },
+     "service-node-port-range": {
+      "type": "string"
+     },
+     "snapshotter": {
+      "type": "string"
+     },
+     "tls-san": {
+      "type": "array"
+     },
+     "tls-san-security": {
+      "type": "boolean"
+     }
+    },
+    "version": "v1.29.14+rke2r1"
    },
    {
     "agentArgs": {

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -259,6 +259,7 @@ sync:
         - v1.29.11-rke2r1-build20241202
         - v1.29.12-rke2r1-build20241212
         - v1.29.13-rke2r1-build20250117
+        - v1.29.14-rke2r1-build20250213
         - v1.29.3-rke2r1-build20240315
         - v1.29.4-rke2r1-build20240416
         - v1.29.5-rke2r1-build20240515
@@ -554,6 +555,7 @@ sync:
         - v1.29.11-k3s1
         - v1.29.12-k3s1
         - v1.29.13-k3s1
+        - v1.29.14-k3s1
         - v1.29.3-k3s1
         - v1.29.4-k3s1
         - v1.29.5-k3s1
@@ -1575,6 +1577,8 @@ sync:
         - v1.29.12-rke2r1-windows-amd64
         - v1.29.13-rke2r1
         - v1.29.13-rke2r1-windows-amd64
+        - v1.29.14-rke2r1
+        - v1.29.14-rke2r1-windows-amd64
         - v1.29.3-rke2r1
         - v1.29.3-rke2r1-windows-amd64
         - v1.29.4-rke2r1
@@ -1689,6 +1693,7 @@ sync:
         - v1.29.11-rke2r1
         - v1.29.12-rke2r1
         - v1.29.13-rke2r1
+        - v1.29.14-rke2r1
         - v1.29.3-rke2r1
         - v1.29.4-rke2r1
         - v1.29.5-rke2r1
@@ -1776,6 +1781,7 @@ sync:
         - v1.29.11-k3s1
         - v1.29.12-k3s1
         - v1.29.13-k3s1
+        - v1.29.14-k3s1
         - v1.29.3-k3s1
         - v1.29.4-k3s1
         - v1.29.5-k3s1
@@ -1863,6 +1869,7 @@ sync:
         - v1.29.11-rke2r1
         - v1.29.12-rke2r1
         - v1.29.13-rke2r1
+        - v1.29.14-rke2r1
         - v1.29.3-rke2r1
         - v1.29.4-rke2r1
         - v1.29.5-rke2r1


### PR DESCRIPTION
v1.29.14 was missed for RKE2 and K3s, but not for RKE1. 

While not strictly necessary this was tripping up our release CI validations https://github.com/rancher/kontainer-driver-metadata/actions/runs/13934609189/job/38999692879. It's safer to have any previously released versions available in new release line's KDM data.