### PR TITLE
[dev-v2.11] Update validation script

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,4 +24,4 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Checking if released versions are not changed
-go run ./pkg/validation/validation.go release-v2.10
+go run ./pkg/validation/validation.go release-v2.11


### PR DESCRIPTION
Modify the validation script to check against the latest release version v2.11 instead of v2.10.

http://github.com/rancher/rancher/issues/49076