### PR TITLE
Prepare the dev-v2.12 Branch 

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -82,25 +82,3 @@ jobs:
           process_gcloudignore: false
           headers: |-
             cache-control: public,no-cache,proxy-revalidate
-
-  dispatch:
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: upload
-    if: github.event_name == 'push' && (github.ref_name == 'release-v2.11' || github.ref_name == 'dev-v2.11')
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Retrieve token from vault
-        uses: rancher-eio/read-vault-secrets@main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/github-token/credentials token | PAT_TOKEN
-      - name: Run dispatch
-        run: |
-          gh workflow run "Go Generate" --repo rancher/rke --ref release/v1.8 -F source_author=${{ github.actor }}
-        env:
-          GH_TOKEN: ${{ env.PAT_TOKEN }}

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -24,6 +24,8 @@ appDefaults:
         defaultVersion: '1.31.x'
       - appVersion: '>= 2.11.0-0 < 2.12.100-0'
         defaultVersion: '1.32.x'
+      - appVersion: '>= 2.12.0-0 < 2.13.100-0'
+        defaultVersion: '1.32.x' # todo: change to 1.33.x once it is added
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
@@ -3297,7 +3299,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.8+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.11.99
+    maxChannelServerVersion: v2.12.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-8-rke2r1
@@ -3413,7 +3415,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.4+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.11.99
+    maxChannelServerVersion: v2.12.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-4-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -24,6 +24,8 @@ appDefaults:
         defaultVersion: '1.31.x'
       - appVersion: '>= 2.11.0-0 < 2.12.100-0'
         defaultVersion: '1.32.x'
+      - appVersion: '>= 2.12.0-0 < 2.13.100-0'
+        defaultVersion: '1.32.x' # todo: change to 1.33.x once it is added
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1
@@ -855,7 +857,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.8+k3s1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.11.99
+    maxChannelServerVersion: v2.12.99
     serverArgs: *serverArgs-v10
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
@@ -879,7 +881,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.4+k3s1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.11.99
+    maxChannelServerVersion: v2.12.99
     serverArgs: *serverArgs-v10
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -17485,6 +17485,10 @@
      {
       "appVersion": "\u003e= 2.11.0-0 \u003c 2.12.100-0",
       "defaultVersion": "1.32.x"
+     },
+     {
+      "appVersion": "\u003e= 2.12.0-0 \u003c 2.13.100-0",
+      "defaultVersion": "1.32.x"
      }
     ]
    }
@@ -37048,7 +37052,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.11.99",
+    "maxChannelServerVersion": "v2.12.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -37867,7 +37871,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.11.99",
+    "maxChannelServerVersion": "v2.12.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -38047,6 +38051,10 @@
      },
      {
       "appVersion": "\u003e= 2.11.0-0 \u003c 2.12.100-0",
+      "defaultVersion": "1.32.x"
+     },
+     {
+      "appVersion": "\u003e= 2.12.0-0 \u003c 2.13.100-0",
       "defaultVersion": "1.32.x"
      }
     ]
@@ -70256,7 +70264,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.11.99",
+    "maxChannelServerVersion": "v2.12.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -71540,7 +71548,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.11.99",
+    "maxChannelServerVersion": "v2.12.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/50223

The dev-2.12 branch has been cloned from the existing dev-v2.11 branch.

This PR introduces the following changes:

* Removes the workflow step that triggers the `go generate` workflow in the RKE repository.
* Updates the version range for RKE2/K3s 1.31.8 and 1.32.4 to make them available in Rancher 2.12.
* Temporarily sets version 1.32 as the default Kubernetes version for Rancher 2.12.


Next Step:
- Update r/r to use this new branch 