### PR TITLE
[v2.11] Remove validation for encrypted key for April 2025 distro releases

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -205,7 +205,7 @@ func validateEncryptedKeyRotation(release map[string]interface{}) error {
 	// the encrypted-key-rotation key to exist when this validation is being written
 	const firstVersionToCheckEncryptedKeyRotation = "v1.25.11"
 	compareVersions := semver.Compare(firstVersionToCheckEncryptedKeyRotation, version)
-	if compareVersions != 0 && compareVersions != -1 {
+	if compareVersions > 0 || strings.Contains("v1.30.12+rke2r1,v1.31.8+rke2r1,v1.32.4+rke2r1", version) {
 		return nil
 	}
 	logrus.Info("validating encrypted key rotation key on version: " + version)


### PR DESCRIPTION
### Proposed Changes

- Remove validation for April 2025 releases
- A little refactor for compareVersions since semver.Compare will only return -1, 0 and 1.