### PR TITLE
[v2.12] Refactor image tags validation by removing RKE checks

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 
 	utiliies "github.com/rancher/kontainer-driver-metadata/pkg"
@@ -123,7 +122,7 @@ func getImageTags(source []byte) (imageTags, error) {
 // validate checks the versions in the local data.json by comparing with the released data.json,
 // Supported releases are RKE, RKE2 and K3s.
 func validate(dev, released kdm.Data) error {
-	for _, distro := range []string{utiliies.RKE, utiliies.RKE2, utiliies.K3S} {
+	for _, distro := range []string{utiliies.RKE2, utiliies.K3S} {
 		if err := validateDistro(distro, dev, released); err != nil {
 			return fmt.Errorf("failed to validate the distro [%s]: %v", distro, err)
 		}
@@ -150,13 +149,8 @@ func validateDistro(distro string, dev, released kdm.Data) error {
 		if !dv[version] {
 			return fmt.Errorf("a released version [%s] is missing in the dev data", version)
 		}
-		if distro == utiliies.RKE {
-			// RKE release images cannot be changed after the fact
-			if !reflect.DeepEqual(released.K8sVersionRKESystemImages[version], dev.K8sVersionRKESystemImages[version]) {
-				return fmt.Errorf("image(s) for a released version [%s] is changed in the dev data", version)
-			}
-		}
 	}
+
 	// check charts for RKE2 release
 	if distro == utiliies.RKE2 {
 		raw, _, err := unstructured.NestedSlice(dev.RKE2, "releases")
@@ -310,13 +304,6 @@ func getVersions(distro string, dev, released kdm.Data) (devVersions, releasedVe
 	}
 
 	switch distro {
-	case utiliies.RKE:
-		for version := range dev.K8sVersionRKESystemImages {
-			devVersions = append(devVersions, version)
-		}
-		for version := range released.K8sVersionRKESystemImages {
-			releasedVersions = append(releasedVersions, version)
-		}
 	case utiliies.RKE2:
 		devVersions, err = helper(dev.RKE2)
 		if err != nil {


### PR DESCRIPTION
ref: https://github.com/rancher/rancher/issues/49686
Remove RKE validation from the image tags comparison to streamline the validation process for supported releases. 