### PR TITLE
Add publish-test-results job that is ran on Provisioning tests completion

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -1,0 +1,41 @@
+name: Publish Tests Results
+on:
+  workflow_run:
+    workflows: ["Provisioning tests"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  publish-provisioning-test-results:
+    runs-on: runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+    steps:
+      - name: mkdir test-results
+        run: mkdir -p /tmp/test-results
+
+      - name: Download All XML Test Reports
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/test-results/
+          merge-multiple: true
+          pattern: '*.xml'
+
+      - name: Download the Event File
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/test-results/
+          pattern: 'event.json'
+
+      - name: Publish Test Results
+        uses: rancher/publish-unit-test-result-action/linux@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6
+        if: (!cancelled())
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_name: ${{ github.event.workflow_run.event }}
+          event_file: /tmp/test-results/event.json
+          files: "/tmp/test-results/*.xml"


### PR DESCRIPTION
This PR is a pre-requisite for #1643 - this job will run after PRs complete and publish the test results back to the PR.

This is done this way for [security reasons](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) - it's kind of like having the "trusted" workflow get called with a r/w token after something completes this way a rogue PR can't come in and have write access.  