### PR TITLE
[CI] specify run-id for publish-test-results job 

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Download All XML Test Reports
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           path: /tmp/test-results/
           merge-multiple: true
           pattern: '*.xml'
@@ -28,6 +29,7 @@ jobs:
       - name: Download the Event File
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           path: /tmp/test-results/
           pattern: 'event.json'
 


### PR DESCRIPTION
Currently when the publish-test-results job is ran it fails to find any xml files or the event file - which should definitely exist. This is seemingly due to the fact that by default the scope is the current run (not the one that called the job).