### PR TITLE
[CI] Download everything from the previous run rather than filtering by file

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -26,15 +26,28 @@ jobs:
           github-token: ${{ github.token }}
           merge-multiple: true
           path: /tmp/test-results/
-          pattern: '*.xml'
+          name: "XML Results"
 
       - name: Download the Event File
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
+          merge-multiple: true
           path: /tmp/test-results/
-          pattern: 'event.json'
+          name: "Event File"
+
+      - run: ls -l /tmp/test-results/
+
+      - name: [Debug] Downloading everything
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          merge-multiple: true
+          path: /tmp/test-results/
+
+      - run: ls -l /tmp/test-results/
 
       - name: Publish Test Results
         uses: rancher/publish-unit-test-result-action/linux@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6


### PR DESCRIPTION
Looks like the last run worked - but nothing matched the file pattern (unlike when I was developing this over on r/r).

This adds a few steps - notably downloading the files by name - then downloading EVERYTHING to see if it works. 