### PR TITLE
[v2.13] update server versions for v2.13

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2834,7 +2834,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-9-rke2r1
@@ -2884,7 +2884,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.10+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-10-rke2r1
@@ -2922,7 +2922,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.11+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-11-rke2r1
@@ -2948,7 +2948,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.12+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-12-rke2r1
@@ -2984,7 +2984,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-13-rke2r1
@@ -3022,7 +3022,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-30-14-rke2r1
       <<: *charts-v1-30-13-rke2r1
       rke2-canal:
@@ -3375,7 +3375,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.8+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-8-rke2r1
@@ -3411,7 +3411,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.31.9+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-9-rke2r1
@@ -3449,7 +3449,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.10+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-31-10-rke2r1
       <<: *charts-v1-31-9-rke2r1
       rke2-metrics-server:
@@ -3486,7 +3486,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.11+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-31-11-rke2r1
       <<: *chartsv1-31-10-rke2r1
       harvester-csi-driver:
@@ -3604,7 +3604,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.4+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-4-rke2r1
@@ -3640,7 +3640,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.32.5+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-5-rke2r1
@@ -3678,7 +3678,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.6+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-32-6-rke2r1
       <<: *charts-v1-32-5-rke2r1
       rke2-canal:
@@ -3715,7 +3715,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.7+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-32-7-rke2r1
       <<: *chartsv1-32-6-rke2r1
       rke2-flannel:
@@ -3752,7 +3752,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.0+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-33-0-rke2r1
@@ -3767,7 +3767,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.33.1+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-33-1-rke2r1
       <<: *charts-v1-33-0-rke2r1
       rke2-canal:
@@ -3807,7 +3807,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.2+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-33-2-rke2r1
       <<: *chartsv1-33-1-rke2r1
       rke2-calico:
@@ -3844,7 +3844,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.3+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     charts: &chartsv1-33-3-rke2r1
       <<: *chartsv1-33-2-rke2r1
       rke2-flannel:

--- a/channels.yaml
+++ b/channels.yaml
@@ -788,25 +788,25 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.10+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.11+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.12+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: &serverArgs-v10
       <<: *serverArgs-v9
       secrets-encryption-provider:
@@ -816,7 +816,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: &serverArgs-v11
       <<: *serverArgs-v10
       etcd-s3-bucket-lookup-type:
@@ -830,7 +830,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
@@ -878,26 +878,26 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.31.8+k3s1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v10
     agentArgs: *agentArgs-v7
     # featureVersions: *featureVersions-v1
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.31.9+k3s1
     minChannelServerVersion: v2.10.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.31.10+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.31.11+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
@@ -921,32 +921,32 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.32.4+k3s1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v10
     agentArgs: *agentArgs-v7
     # featureVersions: *featureVersions-v1
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.32.5+k3s1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.32.6+k3s1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.32.7+k3s1
     minChannelServerVersion: v2.11.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.0+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: &serverArgs-v11
       <<: *serverArgs-v10
       secrets-encryption-provider:
@@ -960,19 +960,19 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.33.1+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.2+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.3+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.13.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -17391,7 +17391,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17595,7 +17595,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17799,7 +17799,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18000,7 +18000,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18207,7 +18207,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18423,7 +18423,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -20046,7 +20046,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -20253,7 +20253,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -20469,7 +20469,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -20685,7 +20685,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -21510,7 +21510,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -21717,7 +21717,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -21933,7 +21933,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22149,7 +22149,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22362,7 +22362,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22574,7 +22574,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22786,7 +22786,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -22998,7 +22998,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -51564,7 +51564,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -51885,7 +51885,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -52206,7 +52206,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -52524,7 +52524,7 @@
       "version": "27.0.202"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -52845,7 +52845,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -53166,7 +53166,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -56032,7 +56032,7 @@
       "version": "27.0.202"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -56353,7 +56353,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -56674,7 +56674,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -56995,7 +56995,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.10.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -58276,7 +58276,7 @@
       "version": "34.2.002"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -58597,7 +58597,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -58918,7 +58918,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -59239,7 +59239,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.11.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -59557,7 +59557,7 @@
       "version": "34.2.002"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -59878,7 +59878,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -60199,7 +60199,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -60520,7 +60520,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.13.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
Will update to `v2.13-head` once rancher branch is created: 
https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.12/Dockerfile.dapper#L1 