### PR TITLE
[v2.11] update go to 1.24

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.11-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher
@@ -64,12 +64,12 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV GOLANGCI_LINT v1.60.3
+ENV GOLANGCI_LINT v1.64.7
 
 RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
+        GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \
         curl -sL https://github.com/regclient/regclient/releases/download/v0.7.1/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/kontainer-driver-metadata
 
-go 1.22
+go 1.24
 
 replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -286,13 +286,13 @@ func releaseToKeep(release map[string]interface{}) (bool, error) {
 	}
 	minChannelServerVersion, ok := release["minChannelServerVersion"].(string)
 	if ok && minChannelServerVersion != "" {
-		if min, err := semver.ParseTolerant(minChannelServerVersion); err != nil || min.GE(maxAllowedServerVersion) {
+		if minVersion, err := semver.ParseTolerant(minChannelServerVersion); err != nil || minVersion.GE(maxAllowedServerVersion) {
 			return false, err
 		}
 	}
 	maxChannelServerVersion, ok := release["maxChannelServerVersion"].(string)
 	if ok && maxChannelServerVersion != "" {
-		if max, err := semver.ParseTolerant(maxChannelServerVersion); err != nil || max.LT(minAllowedServerVersion) {
+		if maxVersion, err := semver.ParseTolerant(maxChannelServerVersion); err != nil || maxVersion.LT(minAllowedServerVersion) {
 			return false, err
 		}
 	}
@@ -312,21 +312,21 @@ func toKeep(info v3.K8sVersionInfo) (bool, error) {
 		}
 	}
 	if info.MinRancherVersion != "" {
-		min, err := semver.ParseTolerant(info.MinRancherVersion)
+		minVersion, err := semver.ParseTolerant(info.MinRancherVersion)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse %s: %v", info.MinRancherVersion, err)
 		}
-		if min.GE(maxAllowedServerVersion) {
+		if minVersion.GE(maxAllowedServerVersion) {
 			return false, nil
 		}
 	}
 
 	if info.MaxRancherVersion != "" {
-		max, err := semver.ParseTolerant(info.MaxRancherVersion)
+		maxVersion, err := semver.ParseTolerant(info.MaxRancherVersion)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse %s: %v", info.MaxRancherVersion, err)
 		}
-		if max.LT(minAllowedServerVersion) {
+		if maxVersion.LT(minAllowedServerVersion) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
- Updated Go to fix CI failure, `v2.11-head` was updated recently to use go1.24: 
```
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
``` 

- Upgraded golangci-lint to v1.64.x to support Go 1.24.
Previous version (v1.63.x) failed with the following error:
```
failed to load export data: internal error in importing "github.com/rancher/rke/types/kdm" (unsupported version: 2)
```

- Changed installation method from `curl | sh` (which downloads a prebuilt binary) to `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7`. This ensures the binary is compiled using Go 1.24 inside the container.

Using the curl installer caused this error due to the binary being built with an older Go version (e.g. Go 1.23):
```
can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24)
```