### PR TITLE
Fix CI for mirroring images

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -66,12 +66,12 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 ENV GOLANGCI_LINT v1.64.7
 
-RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
+RUN zypper -n install git docker vim less file curl wget jq awk ruby && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \
-        curl -sL https://github.com/regclient/regclient/releases/download/v0.7.1/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
+        curl -sL https://github.com/regclient/regclient/releases/download/v0.9.0/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
 ENV YQ_VERSION v4.41.1

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -76,6 +77,11 @@ func GenerateRegSyncFile() {
 		logrus.Fatalf("failed to create the regsync file: %v ", err)
 	}
 	defer file.Close()
+
+	// sort values to keep the order deterministic
+	for _, tags := range extendedLifeImages {
+		sort.Strings(tags)
+	}
 
 	data := struct {
 		Images             map[string]map[string]bool

--- a/scripts/mirror-images
+++ b/scripts/mirror-images
@@ -3,5 +3,12 @@ set -e
 
 cd $(dirname $0)/..
 
-echo Regsync mirroring images
-regsync once --missing --config ./regsync.yaml
+echo "Regsync: splitting regsync file..."
+ruby ./scripts/regsync-split.rb
+
+echo "Regsync: mirroring images from split configs..."
+find ./split-regsync -name 'split-regsync.yaml' | while read -r file; do
+  echo "Syncing with: $file"
+  regsync once --missing --config "$file" -v debug
+done
+

--- a/scripts/regsync-split.rb
+++ b/scripts/regsync-split.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "pathname"
+require "yaml"
+require "pp"
+
+# Determine paths
+script_dir = Pathname.new(__FILE__).realpath.dirname
+repo_root = script_dir.parent
+config_file_path = repo_root + "regsync.yaml"
+
+pp script_dir
+pp repo_root
+pp config_file_path
+
+unless config_file_path.exist?
+  abort "Error: Config file not found at: #{config_file_path}"
+end
+
+# Load the main config
+regsync = YAML.load_file(config_file_path)
+
+# Count total tags
+sum = regsync["sync"].sum do |sync|
+  allow_tags = sync.dig("tags", "allow") || []
+  allow_tags.count
+end
+
+puts "Total tags to consider: #{sum}"
+
+# Split each sync block
+regsync["sync"].each do |sync|
+  single_sync_config = regsync.merge("sync" => [sync])
+
+  target_dir = repo_root + "split-regsync" + sync["source"]
+  target_dir.mkpath
+
+  output_file = target_dir + "split-regsync.yaml"
+  output_file.write(YAML.dump(single_sync_config))
+
+  puts "Wrote split config: #{output_file}"
+end
+


### PR DESCRIPTION
CI failures due to regsync running into problems fetching tags, debug logs for reference: 
```
time="2025-08-20T20:24:58Z" level=debug msg="Auth scope added" host=registry-1.docker.io scope="repository:***/mirrored-k8s-dns-dnsmasq-nanny:pull"
time="2025-08-20T20:24:58Z" level=debug msg="http req" method=GET url="https://registry-1.docker.io/v2/***/mirrored-k8s-dns-dnsmasq-nanny/tags/list" withAuth=true
time="2025-08-20T20:24:58Z" level=debug msg="Request failed" Status="Bad Request" URL="https://registry-1.docker.io/v2/***/mirrored-k8s-dns-dnsmasq-nanny/tags/list"
time="2025-08-20T20:24:58Z" level=error msg="Failed getting source tags" error="failed to list tags for docker.io/***/mirrored-k8s-dns-dnsmasq-nanny:latest: request failed: unexpected http status code: Bad Request [http 400]: <html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n<
``` 
It starts out fine, but after a few images it fails with `Bad Request` errors. I have confirmed that it's not specific to a particular image by changing the order. 

Worked with EIO to resolve this, and while we are not certain about the root cause - the fix is to split the `regsync.yaml` into parts based on the source and invoke regysnc on them individually. This helps avoid any token validity or limit issues we might be running into. 

The script is a modified version from https://github.com/rancher/charts/blob/dev-v2.12/scripts/regsync-split.rb for ruby 2.5 (zypper on current Dockerfile's image installs 2.5). 

**Note:** 
I had to commit change to the release branch first to verify the fix works, so it's syncing the change from release to dev. Link to successful run: https://github.com/rancher/kontainer-driver-metadata/actions/runs/17113895706