### PR TITLE
[v2.12] update branch for v2.12 in validate-ci

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,4 +24,4 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Checking if released versions are not changed
-go run ./pkg/validation/validation.go release-v2.11
+go run ./pkg/validation/validation.go release-v2.12


### PR DESCRIPTION
`release-v2.12` was created for last release (v2.12.0) so updating CI run validation checks against it and not `release-v2.11`. 