### PR TITLE
[v2.12] update max channel server version for v1.30.x

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2834,7 +2834,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-9-rke2r1
@@ -2884,7 +2884,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.10+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-10-rke2r1
@@ -2922,7 +2922,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.11+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-11-rke2r1
@@ -2948,7 +2948,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.12+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-12-rke2r1
@@ -2984,7 +2984,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-13-rke2r1
@@ -3022,7 +3022,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     charts: &chartsv1-30-14-rke2r1
       <<: *charts-v1-30-13-rke2r1
       rke2-canal:
@@ -3059,7 +3059,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+rke2r2
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     charts: &chartsv1-30-14-rke2r2
       <<: *chartsv1-30-14-rke2r1
       rke2-snapshot-controller-crd:

--- a/channels.yaml
+++ b/channels.yaml
@@ -788,25 +788,25 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.10+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.11+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.12+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: &serverArgs-v10
       <<: *serverArgs-v9
       secrets-encryption-provider:
@@ -816,7 +816,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: &serverArgs-v11
       <<: *serverArgs-v10
       etcd-s3-bucket-lookup-type:
@@ -830,13 +830,13 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.14+k3s2
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.12.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -17391,7 +17391,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17595,7 +17595,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17799,7 +17799,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18000,7 +18000,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18207,7 +18207,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18423,7 +18423,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18639,7 +18639,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -52424,7 +52424,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -52745,7 +52745,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -53066,7 +53066,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -53384,7 +53384,7 @@
       "version": "27.0.202"
      }
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -53705,7 +53705,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -54026,7 +54026,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -54347,7 +54347,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.12.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
v1.30 is not supported in v2.12.0. v1.30 clusters must be upgraded before upgrading Rancher to v2.12.x. 
https://github.com/rancher/rancher/issues/51908