### PR TITLE
[dev-v2.10] Fix goimports version to fix CI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -69,7 +69,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 ENV GOLANGCI_LINT v1.60.3
 
 RUN zypper -n install git docker vim less file curl wget jq awk ruby && rpm -e --nodeps --noscripts containerd
-RUN go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/tools/cmd/goimports@v0.36.0
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \


### PR DESCRIPTION
The @latest version of golang.org/x/tools/cmd/goimports started requiring go 1.24 in its mod file as of September, which caused CI to fail since Dockerfile.dapper uses go1.23.