### PR TITLE
[dev-v2.13] fix maxChannelServerVersion for v1.30.x

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2836,7 +2836,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-9-rke2r1
@@ -2886,7 +2886,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.10+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-10-rke2r1
@@ -2924,7 +2924,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.11+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-11-rke2r1
@@ -2950,7 +2950,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.12+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-12-rke2r1
@@ -2986,7 +2986,7 @@ releases:
         # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v1-28-11-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-13-rke2r1
@@ -3024,7 +3024,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     charts: &chartsv1-30-14-rke2r1
       <<: *charts-v1-30-13-rke2r1
       rke2-canal:
@@ -3061,7 +3061,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+rke2r2
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     charts: &chartsv1-30-14-rke2r2
       <<: *chartsv1-30-14-rke2r1
       rke2-snapshot-controller-crd:

--- a/channels.yaml
+++ b/channels.yaml
@@ -790,25 +790,25 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.9+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.10+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.11+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v9
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.12+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: &serverArgs-v10
       <<: *serverArgs-v9
       secrets-encryption-provider:
@@ -818,7 +818,7 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.30.13+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: &serverArgs-v11
       <<: *serverArgs-v10
       etcd-s3-bucket-lookup-type:
@@ -832,13 +832,13 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.30.14+k3s1
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.30.14+k3s2
     minChannelServerVersion: v2.9.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.11.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -17395,7 +17395,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17599,7 +17599,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -17803,7 +17803,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18004,7 +18004,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18211,7 +18211,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18427,7 +18427,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -18643,7 +18643,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -53402,7 +53402,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -53723,7 +53723,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -54044,7 +54044,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -54362,7 +54362,7 @@
       "version": "27.0.202"
      }
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -54683,7 +54683,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -55004,7 +55004,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -55325,7 +55325,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.11.99",
     "minChannelServerVersion": "v2.9.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/51253
- the maxChannelServerVersion was set to v2.13.99 for v1.30.x releases so updated it to v2.11.99 (same as dev-v2.12)