### PR TITLE
[release-v2.13] update server versions for v2.13

### DIFF
--- a/scripts/mirror-images
+++ b/scripts/mirror-images
@@ -4,4 +4,4 @@ set -e
 cd $(dirname $0)/..
 
 echo Regsync mirroring images
-regsync once --missing --config ./regsync.yaml
+regsync once --missing --config ./regsync.yaml  --verbosity debug


### PR DESCRIPTION
**This PR is against the release-v2.13 branch as it is the only way to trigger the regsync workflow.   No breaking changes are introduced in this PR.** 


## Problem

The regsync run in the CI fails with the following kind of errors:

`time="2025-11-10T19:04:14Z" level=error msg="Failed getting source tags" error="failed to list tags for docker.io/***/mirrored-longhornio-csi-node-driver-registrar:latest: request failed: unexpected http status code: Bad Request [http 400]: <html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n</body>\r\n</html>\r\n" source="docker.io/***/mirrored-longhornio-csi-node-driver-registrar:latest"`


The error message is somewhat **misleading** — it indicates a failure to pull the latest tag, but in reality, the process only retrieves the list of available tags from the source. No specific tag is actually sent in the request to the Docker Hub server. The latest tag is simply set as a default value in the reference object when no tag or digest is provided, which applies in our case.

- https://github.com/regclient/regclient/blob/v0.7.1/scheme/reg/tag.go#L265-L281 
- https://github.com/regclient/regclient/blob/v0.7.1/types/ref/ref.go#L99-L101 


Another observation is that the first failed image, `mirrored-longhornio-csi-node-driver-registrar`, appears around the **70th** entry in the list, meaning the first 69 images were processed successfully. But it is also unlikely related to Docker Hub rate limiting, as Docker Hub typically responds with a `429 Too Many Requests` error when rate limits are exceeded.
See https://docs.docker.com/docker-hub/usage/#abuse-rate-limit

## (Not really) Fix

To better determine the root cause, we should enable debug-level logging to capture more details about the process at the point of failure.


Also note that the latest version of regsync is v0.8.0, while we are currently using v0.7.1.
 

-----

For reference: 
```
> regsync once -h
Processes each sync command in the configuration file in order.
No jobs are run in parallel, and the command returns after any error or last
sync step is finished.

Usage:
  regsync once [flags]

Flags:
  -h, --help      help for once
      --missing   Only copy tags that are missing on target

Global Flags:
  -c, --config string        Config file
      --logopt stringArray   Log options
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "info")
```

```
> regsync version
VCSTag:     v0.7.1
VCSRef:     cdfb08e81b172a64860eb95f8092c08d0c121b04
VCSCommit:  cdfb08e81b172a64860eb95f8092c08d0c121b04
VCSState:   clean
VCSDate:    2024-08-03T19:57:30Z
Platform:   darwin/arm64
GoVer:      go1.22.5
GoCompiler: gc
```