### PR TITLE
[dev-v2.13] Forward-port CI fixes

### DIFF
--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -1,4 +1,4 @@
-name: Publish Tests Results
+name: Publish Provisioning Tests Results
 on:
   workflow_run:
     workflows: ["Provisioning tests"]
@@ -37,22 +37,11 @@ jobs:
           path: /tmp/test-results/
           name: "Event File"
 
-      - run: ls -l /tmp/test-results/
-
-      - name: "[Debug] Downloading everything"
-        uses: actions/download-artifact@v4
-        with:
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-          merge-multiple: true
-          path: /tmp/test-results/
-
-      - run: ls -l /tmp/test-results/
-
       - name: Publish Test Results
         uses: rancher/publish-unit-test-result-action/linux@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6
         if: (!cancelled())
         with:
+          check_name: Provisioning Tests Results
           commit: ${{ github.event.workflow_run.head_sha }}
           event_name: ${{ github.event.workflow_run.event }}
           event_file: /tmp/test-results/event.json

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -66,12 +66,12 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 ENV GOLANGCI_LINT v1.64.8
 
-RUN zypper -n install git docker vim less file curl wget jq awk && rpm -e --nodeps --noscripts containerd
+RUN zypper -n install git docker vim less file curl wget jq awk ruby && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
         curl -sL https://github.com/rancher/wharfie/releases/download/v0.6.1/wharfie-amd64 -o /bin/wharfie && chmod +x /bin/wharfie; \
-        curl -sL https://github.com/regclient/regclient/releases/download/v0.7.1/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
+        curl -sL https://github.com/regclient/regclient/releases/download/v0.9.0/regsync-linux-amd64 -o /bin/regsync && chmod +x /bin/regsync; \
     fi
 
 ENV YQ_VERSION v4.41.1

--- a/scripts/mirror-images
+++ b/scripts/mirror-images
@@ -3,5 +3,12 @@ set -e
 
 cd $(dirname $0)/..
 
-echo Regsync mirroring images
-regsync once --missing --config ./regsync.yaml
+echo "Regsync: splitting regsync file..."
+ruby ./scripts/regsync-split.rb
+
+echo "Regsync: mirroring images from split configs..."
+find ./split-regsync -name 'split-regsync.yaml' | while read -r file; do
+  echo "Syncing with: $file"
+  regsync once --missing --config "$file" -v debug
+done
+

--- a/scripts/regsync-split.rb
+++ b/scripts/regsync-split.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "pathname"
+require "yaml"
+require "pp"
+
+# Determine paths
+script_dir = Pathname.new(__FILE__).realpath.dirname
+repo_root = script_dir.parent
+config_file_path = repo_root + "regsync.yaml"
+
+pp script_dir
+pp repo_root
+pp config_file_path
+
+unless config_file_path.exist?
+  abort "Error: Config file not found at: #{config_file_path}"
+end
+
+# Load the main config
+regsync = YAML.load_file(config_file_path)
+
+# Count total tags
+sum = regsync["sync"].sum do |sync|
+  allow_tags = sync.dig("tags", "allow") || []
+  allow_tags.count
+end
+
+puts "Total tags to consider: #{sum}"
+
+# Split each sync block
+regsync["sync"].each do |sync|
+  single_sync_config = regsync.merge("sync" => [sync])
+
+  target_dir = repo_root + "split-regsync" + sync["source"]
+  target_dir.mkpath
+
+  output_file = target_dir + "split-regsync.yaml"
+  output_file.write(YAML.dump(single_sync_config))
+
+  puts "Wrote split config: #{output_file}"
+end
+

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,4 +24,4 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Checking if released versions are not changed
-go run ./pkg/validation/validation.go release-v2.11
+go run ./pkg/validation/validation.go release-v2.13


### PR DESCRIPTION
This PR forwards the following fixes from the dev-v2.12 branch:

- https://github.com/rancher/kontainer-driver-metadata/pull/1745
- https://github.com/rancher/kontainer-driver-metadata/pull/1775 - this would fix the **regsync error** 

It also corrects the target branch passed in the validation test 

 
**Next step**

A PR from the dev-v2.13 to release-v2.13 branch will be raised once this PR is merged. 

Currently, the only difference between those branches is changes in the CI 