### PR TITLE
[dev-v2.11-extended-life] add ingress controller flag rke2

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -2119,7 +2119,14 @@ releases:
   - version: v1.28.12+rke2r1
     minChannelServerVersion: v2.8.3-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: &serverArgs-v1-28-12-rke2r1
+      <<: *serverArgs-v1-28-11-rke2r1
+      ingress-controller:
+        type: array
+        options:
+          - ingress-nginx
+          - traefik
+          - none
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-28-12-rke2r1
       <<: *charts-v1-28-11-rke2r1
@@ -2139,7 +2146,7 @@ releases:
   - version: v1.28.13+rke2r1
     minChannelServerVersion: v2.8.3-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-28-13-rke2r1
       <<: *charts-v1-28-12-rke2r1
@@ -2171,7 +2178,7 @@ releases:
   - version: v1.28.14+rke2r1
     minChannelServerVersion: v2.8.3-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-28-14-rke2r1
       <<: *charts-v1-28-13-rke2r1
@@ -2203,7 +2210,7 @@ releases:
   - version: v1.28.15+rke2r1
     minChannelServerVersion: v2.8.3-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-28-15-rke2r1
       <<: *charts-v1-28-14-rke2r1
@@ -2278,7 +2285,14 @@ releases:
   - version: v1.29.7+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: &serverArgs-v1-29-7-rke2r1
+      <<: *serverArgs-v1-28-9-rke2r1
+      ingress-controller:
+        type: array
+        options:
+          - ingress-nginx
+          - traefik
+          - none
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-7-rke2r1
       <<: *charts-v1-28-11-rke2r1
@@ -2298,7 +2312,7 @@ releases:
   - version: v1.29.8+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-8-rke2r1
       <<: *charts-v1-29-7-rke2r1
@@ -2330,7 +2344,7 @@ releases:
   - version: v1.29.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-9-rke2r1
       <<: *charts-v1-29-8-rke2r1
@@ -2362,7 +2376,7 @@ releases:
   - version: v1.29.10+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-10-rke2r1
       <<: *charts-v1-29-9-rke2r1
@@ -2409,7 +2423,7 @@ releases:
   - version: v1.29.11+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-11-rke2r1
       <<: *charts-v1-29-10-rke2r1
@@ -2447,7 +2461,7 @@ releases:
   - version: v1.29.12+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-12-rke2r1
       <<: *charts-v1-29-11-rke2r1
@@ -2479,7 +2493,7 @@ releases:
   - version: v1.29.13+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-13-rke2r1
       <<: *charts-v1-29-12-rke2r1
@@ -2529,7 +2543,7 @@ releases:
   - version: v1.29.14+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-14-rke2r1
       <<: *charts-v1-29-13-rke2r1
@@ -2564,7 +2578,7 @@ releases:
   - version: v1.29.15+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-9-rke2r1
+    serverArgs: *serverArgs-v1-29-7-rke2r1
     agentArgs: *agentArgs-v1-28-8-rke2r1
     charts: &charts-v1-29-15-rke2r1
       <<: *charts-v1-29-14-rke2r1
@@ -2620,7 +2634,7 @@ releases:
   - version: v1.30.3+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-3-rke2r1
       <<: *charts-v1-30-2-rke2r1
@@ -2646,7 +2660,7 @@ releases:
   - version: v1.30.4+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-4-rke2r1
       <<: *charts-v1-30-3-rke2r1
@@ -2678,7 +2692,7 @@ releases:
   - version: v1.30.5+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-5-rke2r1
       <<: *charts-v1-30-4-rke2r1
@@ -2710,7 +2724,7 @@ releases:
   - version: v1.30.6+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-6-rke2r1
       <<: *charts-v1-30-5-rke2r1
@@ -2763,7 +2777,7 @@ releases:
   - version: v1.30.7+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-7-rke2r1
       <<: *charts-v1-30-6-rke2r1
@@ -2801,7 +2815,7 @@ releases:
   - version: v1.30.8+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-8-rke2r1
       <<: *charts-v1-30-7-rke2r1
@@ -2833,7 +2847,7 @@ releases:
   - version: v1.30.9+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-9-rke2r1
       <<: *charts-v1-30-8-rke2r1
@@ -2883,7 +2897,7 @@ releases:
   - version: v1.30.10+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-10-rke2r1
       <<: *charts-v1-30-9-rke2r1
@@ -2921,7 +2935,7 @@ releases:
   - version: v1.30.11+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-11-rke2r1
       <<: *charts-v1-30-10-rke2r1
@@ -2947,7 +2961,7 @@ releases:
   - version: v1.30.12+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-12-rke2r1
       <<: *charts-v1-30-11-rke2r1
@@ -2983,7 +2997,7 @@ releases:
   - version: v1.30.13+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-30-13-rke2r1
       <<: *charts-v1-30-12-rke2r1
@@ -3051,7 +3065,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.42.302
     serverArgs: &serverArgsv1-30-14-rke2r1
-      <<: *serverArgs-v1-28-11-rke2r1
+      <<: *serverArgs-v1-28-12-rke2r1
     agentArgs: &agentArgsv1-30-14-rke2r1
       <<: *agentArgs-v1-28-11-rke2r1
     featureVersions: *featureVersions-v1
@@ -3095,7 +3109,8 @@ releases:
   - version: v1.31.0+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.9.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: &serverArgs-v1-31-0-rke2r1
+      <<: *serverArgs-v1-28-12-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-0-rke2r1
       <<: *charts-v1-30-4-rke2r1
@@ -3145,7 +3160,7 @@ releases:
   - version: v1.31.1+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-1-rke2r1
       <<: *charts-v1-31-0-rke2r1
@@ -3174,7 +3189,7 @@ releases:
   - version: v1.31.2+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-2-rke2r1
       <<: *charts-v1-31-1-rke2r1
@@ -3227,7 +3242,7 @@ releases:
   - version: v1.31.3+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-3-rke2r1
       <<: *charts-v1-31-2-rke2r1
@@ -3265,7 +3280,7 @@ releases:
   - version: v1.31.4+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.10.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-4-rke2r1
       <<: *charts-v1-31-3-rke2r1
@@ -3297,7 +3312,7 @@ releases:
   - version: v1.31.5+rke2r1
     minChannelServerVersion: v2.9.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-5-rke2r1
       <<: *charts-v1-31-4-rke2r1
@@ -3347,7 +3362,7 @@ releases:
   - version: v1.31.6+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-6-rke2r1
       <<: *charts-v1-31-5-rke2r1
@@ -3385,7 +3400,7 @@ releases:
   - version: v1.31.7+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-7-rke2r1
       <<: *charts-v1-31-6-rke2r1
@@ -3411,7 +3426,7 @@ releases:
   - version: v1.31.8+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-8-rke2r1
       <<: *charts-v1-31-7-rke2r1
@@ -3447,7 +3462,7 @@ releases:
   - version: v1.31.9+rke2r1
     minChannelServerVersion: v2.10.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-31-9-rke2r1
       <<: *charts-v1-31-8-rke2r1
@@ -3515,7 +3530,7 @@ releases:
         repo: rancher-rke2-charts
         version: 3.12.202
     serverArgs: &serverArgsv1-31-10-rke2r1
-      <<: *serverArgs-v1-28-11-rke2r1
+      <<: *serverArgs-v1-31-0-rke2r1
     agentArgs: &agentArgsv1-31-10-rke2r1
       <<: *agentArgs-v1-28-11-rke2r1
     featureVersions: *featureVersions-v1
@@ -3713,7 +3728,7 @@ releases:
   - version: v1.32.1+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-1-rke2r1
       <<: *charts-v1-31-5-rke2r1
@@ -3730,7 +3745,7 @@ releases:
   - version: v1.32.2+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-2-rke2r1
       <<: *charts-v1-32-1-rke2r1
@@ -3768,7 +3783,7 @@ releases:
   - version: v1.32.3+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-3-rke2r1
       <<: *charts-v1-32-2-rke2r1
@@ -3794,7 +3809,7 @@ releases:
   - version: v1.32.4+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-4-rke2r1
       <<: *charts-v1-32-3-rke2r1
@@ -3830,7 +3845,7 @@ releases:
   - version: v1.32.5+rke2r1
     minChannelServerVersion: v2.11.0-alpha1
     maxChannelServerVersion: v2.11.99
-    serverArgs: *serverArgs-v1-28-11-rke2r1
+    serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-32-5-rke2r1
       <<: *charts-v1-32-4-rke2r1
@@ -3898,7 +3913,7 @@ releases:
         repo: rancher-rke2-charts
         version: 1.17.401
     serverArgs: &serverArgsv1-32-6-rke2r1
-      <<: *serverArgs-v1-28-11-rke2r1
+      <<: *serverArgs-v1-31-0-rke2r1
     agentArgs: &agentArgsv1-32-6-rke2r1
       <<: *agentArgs-v1-28-11-rke2r1
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -62783,6 +62783,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -63091,6 +63099,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -63401,6 +63417,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -63709,6 +63733,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -65185,6 +65217,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -65481,6 +65521,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -65779,6 +65827,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -66075,6 +66131,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -66373,6 +66437,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -66669,6 +66741,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -66971,6 +67051,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -67272,6 +67360,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -67572,6 +67668,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -68490,6 +68594,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -68806,6 +68918,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -69124,6 +69244,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -69440,6 +69568,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -69758,6 +69894,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -70074,6 +70218,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -70396,6 +70548,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -70716,6 +70876,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -71038,6 +71206,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -71355,6 +71531,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -71677,6 +71861,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -71997,6 +72189,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -72319,6 +72519,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -72635,6 +72843,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -72953,6 +73169,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -73269,6 +73493,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -73587,6 +73819,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -73903,6 +74143,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -74225,6 +74473,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -74545,6 +74801,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -74867,6 +75131,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -75184,6 +75456,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -75506,6 +75786,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -75826,6 +76114,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -76148,6 +76444,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -76468,6 +76772,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -76819,6 +77131,14 @@
      },
      "helm-job-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -77498,6 +77818,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -77818,6 +78146,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -78140,6 +78476,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -78457,6 +78801,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -78779,6 +79131,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -79099,6 +79459,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -79421,6 +79789,14 @@
      "etcd-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -79741,6 +80117,14 @@
      },
      "etcd-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"
@@ -80092,6 +80476,14 @@
      },
      "helm-job-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"

--- a/data/data.json
+++ b/data/data.json
@@ -77494,6 +77494,14 @@
      "helm-job-image": {
       "type": "string"
      },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
+     },
      "kube-apiserver-arg": {
       "type": "array"
      },
@@ -80838,6 +80846,14 @@
      },
      "helm-job-image": {
       "type": "string"
+     },
+     "ingress-controller": {
+      "options": [
+       "ingress-nginx",
+       "traefik",
+       "none"
+      ],
+      "type": "array"
      },
      "kube-apiserver-arg": {
       "type": "array"


### PR DESCRIPTION
Issues:
* https://github.com/rancher/rancher/issues/52763

the version that the flag was added is v1.28.12+rke2r1, v1.29.7+rke2r1, v1.30.3+rke2r1