### PR TITLE
[2.12] Remove max version constraing for regsync.yaml

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -32,7 +32,6 @@ const (
 )
 
 var (
-	maxAllowedServerVersion = semver.MustParse("2.11.0")
 	minAllowedServerVersion = semver.MustParse("2.7.0")
 
 	data     = kdm.Data{}
@@ -248,12 +247,7 @@ func releaseToKeep(release map[string]interface{}) (bool, error) {
 	if !ok || version == "" {
 		return false, fmt.Errorf("the value of the version is missing for the release %v", release)
 	}
-	minChannelServerVersion, ok := release["minChannelServerVersion"].(string)
-	if ok && minChannelServerVersion != "" {
-		if minVer, err := semver.ParseTolerant(minChannelServerVersion); err != nil || minVer.GE(maxAllowedServerVersion) {
-			return false, err
-		}
-	}
+
 	maxChannelServerVersion, ok := release["maxChannelServerVersion"].(string)
 	if ok && maxChannelServerVersion != "" {
 		if maxVer, err := semver.ParseTolerant(maxChannelServerVersion); err != nil || maxVer.LT(minAllowedServerVersion) {

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -17,8 +17,8 @@ func Test_releaseToKeep(t *testing.T) {
 		{
 			name: "invalid Server Version",
 			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "",
-				"maxChannelServerVersion": "v2.6c.7-alpha2.3",
+				"minChannelServerVersion": "v2.6c.7-alpha2.3",
+				"maxChannelServerVersion": "",
 				"version":                 ""},
 			},
 			want:    false,
@@ -35,7 +35,7 @@ func Test_releaseToKeep(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "min < 2.8.0 < 2.9.0 < max",
+			name: "max > 2.7.0",
 			args: args{release: map[string]interface{}{
 				"minChannelServerVersion": "v2.7.0-alpha1",
 				"maxChannelServerVersion": "v2.9.9",
@@ -45,61 +45,20 @@ func Test_releaseToKeep(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "min < 2.8.0 < max = 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.99",
-				"maxChannelServerVersion": "v2.10.0",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "min < 2.7.0 < max < 2.10.0",
+			name: "max = 2.7.0",
 			args: args{release: map[string]interface{}{
 				"minChannelServerVersion": "v2.6.12-alpha1",
-				"maxChannelServerVersion": "v2.9.99",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-
-		{
-			name: "min = 2.7.0 < max < 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.0",
-				"maxChannelServerVersion": "v2.9.99",
+				"maxChannelServerVersion": "v2.7.0",
 				"version":                 "v1.20.15+rke2r2"},
 			},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name: "min = 2.7.0 < max = 2.10.0",
+			name: "max < 2.7.0",
 			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.0",
-				"maxChannelServerVersion": "v2.10.0",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.7.0 < min < max < 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.2-alpha1",
-				"maxChannelServerVersion": "v2.9.14-patch1",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.11.0 < min < 2.11.99 < max",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.11.1-alpha1",
-				"maxChannelServerVersion": "v2.12.0-patch1",
+				"minChannelServerVersion": "v2.6.12-alpha1",
+				"maxChannelServerVersion": "v2.6.14",
 				"version":                 "v1.20.15+rke2r2"},
 			},
 			want:    false,

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -322,6 +322,12 @@ sync:
         - v1.32.7-rke2r1-build20250716
         - v1.32.8-rke2r1-build20250814
         - v1.32.9-rke2r1-build20250910
+        - v1.33.0-rke2r1-build20250425
+        - v1.33.1-rke2r1-build20250515
+        - v1.33.2-rke2r1-build20250618
+        - v1.33.3-rke2r1-build20250716
+        - v1.33.4-rke2r1-build20250814
+        - v1.33.5-rke2r1-build20250910
   - source: docker.io/rancher/hardened-multus-cni
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/hardened-multus-cni'
     type: repository
@@ -577,6 +583,12 @@ sync:
         - v1.32.7-k3s1
         - v1.32.8-k3s1
         - v1.32.9-k3s1
+        - v1.33.0-k3s1
+        - v1.33.1-k3s1
+        - v1.33.2-k3s1
+        - v1.33.3-k3s1
+        - v1.33.4-k3s1
+        - v1.33.5-k3s1
   - source: docker.io/rancher/klipper-helm
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/klipper-helm'
     type: repository
@@ -1168,6 +1180,7 @@ sync:
         - v1.31.1
         - v1.32.1
         - v1.32.2
+        - v1.33.0
   - source: docker.io/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-cloud-provider-vsphere-cpi-release-manager'
     type: repository
@@ -1461,6 +1474,9 @@ sync:
         - v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101
         - v1.32.5-rc1.0.20250516182639-8e8f2a4726fd-build20250612
         - v1.32.8-rc1.0.20250814215348-fe896f7e7cf8-build20250908
+        - v1.33.0-rc1.0.20250430074337-dc03cb4b3faa-build20250430
+        - v1.33.1-0.20250516163953-99d91538b132-build20250612
+        - v1.33.4-rc1.0.20250814212538-148243c49519-build20250908
   - source: docker.io/rancher/rke2-runtime
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/rke2-runtime'
     type: repository
@@ -1674,6 +1690,18 @@ sync:
         - v1.32.8-rke2r1-windows-amd64
         - v1.32.9-rke2r1
         - v1.32.9-rke2r1-windows-amd64
+        - v1.33.0-rke2r1
+        - v1.33.0-rke2r1-windows-amd64
+        - v1.33.1-rke2r1
+        - v1.33.1-rke2r1-windows-amd64
+        - v1.33.2-rke2r1
+        - v1.33.2-rke2r1-windows-amd64
+        - v1.33.3-rke2r1
+        - v1.33.3-rke2r1-windows-amd64
+        - v1.33.4-rke2r1
+        - v1.33.4-rke2r1-windows-amd64
+        - v1.33.5-rke2r1
+        - v1.33.5-rke2r1-windows-amd64
   - source: docker.io/rancher/rke2-upgrade
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/rke2-upgrade'
     type: repository
@@ -1783,6 +1811,12 @@ sync:
         - v1.32.7-rke2r1
         - v1.32.8-rke2r1
         - v1.32.9-rke2r1
+        - v1.33.0-rke2r1
+        - v1.33.1-rke2r1
+        - v1.33.2-rke2r1
+        - v1.33.3-rke2r1
+        - v1.33.4-rke2r1
+        - v1.33.5-rke2r1
   - source: docker.io/rancher/system-agent-installer-k3s
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-k3s'
     type: repository
@@ -1890,6 +1924,12 @@ sync:
         - v1.32.7-k3s1
         - v1.32.8-k3s1
         - v1.32.9-k3s1
+        - v1.33.0-k3s1
+        - v1.33.1-k3s1
+        - v1.33.2-k3s1
+        - v1.33.3-k3s1
+        - v1.33.4-k3s1
+        - v1.33.5-k3s1
   - source: docker.io/rancher/system-agent-installer-rke2
     target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/system-agent-installer-rke2'
     type: repository
@@ -1999,3 +2039,9 @@ sync:
         - v1.32.7-rke2r1
         - v1.32.8-rke2r1
         - v1.32.9-rke2r1
+        - v1.33.0-rke2r1
+        - v1.33.1-rke2r1
+        - v1.33.2-rke2r1
+        - v1.33.3-rke2r1
+        - v1.33.4-rke2r1
+        - v1.33.5-rke2r1


### PR DESCRIPTION
We don't need this because we won't versions that are only supported by more recent channel server versions (Rancher), and removing this is easier than changing the maxAllowedServerVersion whenever there is a new minor.