### PR TITLE
[2.11-rke-extended-life] Remove max version constraing for regsync.yaml

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -37,7 +37,6 @@ const (
 )
 
 var (
-	maxAllowedServerVersion = semver.MustParse("2.11.0")
 	minAllowedServerVersion = semver.MustParse("2.7.0")
 
 	data     = kdm.Data{}
@@ -309,12 +308,7 @@ func releaseToKeep(release map[string]interface{}) (bool, error) {
 	if !ok || version == "" {
 		return false, fmt.Errorf("the value of the version is missing for the release %v", release)
 	}
-	minChannelServerVersion, ok := release["minChannelServerVersion"].(string)
-	if ok && minChannelServerVersion != "" {
-		if minVersion, err := semver.ParseTolerant(minChannelServerVersion); err != nil || minVersion.GE(maxAllowedServerVersion) {
-			return false, err
-		}
-	}
+
 	maxChannelServerVersion, ok := release["maxChannelServerVersion"].(string)
 	if ok && maxChannelServerVersion != "" {
 		if maxVersion, err := semver.ParseTolerant(maxChannelServerVersion); err != nil || maxVersion.LT(minAllowedServerVersion) {
@@ -333,15 +327,6 @@ func toKeep(info v3.K8sVersionInfo) (bool, error) {
 			return false, fmt.Errorf("failed to parse %s: %v", info.DeprecateRancherVersion, err)
 		}
 		if drv.LE(minAllowedServerVersion) {
-			return false, nil
-		}
-	}
-	if info.MinRancherVersion != "" {
-		minVersion, err := semver.ParseTolerant(info.MinRancherVersion)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse %s: %v", info.MinRancherVersion, err)
-		}
-		if minVersion.GE(maxAllowedServerVersion) {
 			return false, nil
 		}
 	}

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -19,8 +19,8 @@ func Test_toKeep(t *testing.T) {
 		{
 			name: "invalid semVer",
 			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.6c.0",
-				MaxRancherVersion:       "",
+				MinRancherVersion:       "",
+				MaxRancherVersion:       "2.6c.0",
 				DeprecateRancherVersion: "",
 			}},
 			want:    false,
@@ -77,7 +77,7 @@ func Test_toKeep(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "min < 2.7.0 < 2.11.0 < max",
+			name: "2.7.0 < max",
 			args: args{info: types.K8sVersionInfo{
 				MinRancherVersion:       "2.6.12-alpha2",
 				MaxRancherVersion:       "2.11.2",
@@ -87,60 +87,30 @@ func Test_toKeep(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "min < 2.7.0 < max = 2.11.0",
+			name: "max = 2.7.0",
 			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.6.12-alpha2",
-				MaxRancherVersion:       "2.11.0",
+				MinRancherVersion:       "2.6.0",
+				MaxRancherVersion:       "2.7.0",
 				DeprecateRancherVersion: "",
 			}},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name: "min < 2.8.0 < max < 2.12.0",
+			name: "max < 2.7.0",
 			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.7.12-alpha2",
-				MaxRancherVersion:       "2.11.12-patch1",
+				MinRancherVersion:       "2.6.0",
+				MaxRancherVersion:       "2.6.5",
 				DeprecateRancherVersion: "",
 			}},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 		{
-			name: "min = 2.7.0 < max < 2.11.0",
+			name: "max < 2.7.0 alpha",
 			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.7.0",
-				MaxRancherVersion:       "2.10.5",
-				DeprecateRancherVersion: "",
-			}},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "min = 2.7.0 < max = 2.11.0",
-			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.7.0",
-				MaxRancherVersion:       "2.11.0",
-				DeprecateRancherVersion: "",
-			}},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.7.0 < min < max < 2.12.0",
-			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.7.1-patch-1",
-				MaxRancherVersion:       "2.11.5",
-				DeprecateRancherVersion: "",
-			}},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.11.0 < min < 2.11.99 < max",
-			args: args{info: types.K8sVersionInfo{
-				MinRancherVersion:       "2.11.1-patch1",
-				MaxRancherVersion:       "2.12.0-alpha1",
+				MinRancherVersion:       "2.6.0",
+				MaxRancherVersion:       "2.7.0-alpha1",
 				DeprecateRancherVersion: "",
 			}},
 			want:    false,
@@ -174,8 +144,8 @@ func Test_releaseToKeep(t *testing.T) {
 		{
 			name: "invalid Server Version",
 			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "",
-				"maxChannelServerVersion": "v2.6c.7-alpha2.3",
+				"minChannelServerVersion": "v2.6c.7-alpha2.3",
+				"maxChannelServerVersion": "",
 				"version":                 ""},
 			},
 			want:    false,
@@ -192,7 +162,7 @@ func Test_releaseToKeep(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "min < 2.8.0 < 2.9.0 < max",
+			name: "max > 2.7.0",
 			args: args{release: map[string]interface{}{
 				"minChannelServerVersion": "v2.7.0-alpha1",
 				"maxChannelServerVersion": "v2.9.9",
@@ -202,61 +172,20 @@ func Test_releaseToKeep(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "min < 2.8.0 < max = 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.99",
-				"maxChannelServerVersion": "v2.10.0",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "min < 2.7.0 < max < 2.10.0",
+			name: "max = 2.7.0",
 			args: args{release: map[string]interface{}{
 				"minChannelServerVersion": "v2.6.12-alpha1",
-				"maxChannelServerVersion": "v2.9.99",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-
-		{
-			name: "min = 2.7.0 < max < 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.0",
-				"maxChannelServerVersion": "v2.9.99",
+				"maxChannelServerVersion": "v2.7.0",
 				"version":                 "v1.20.15+rke2r2"},
 			},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name: "min = 2.7.0 < max = 2.10.0",
+			name: "max < 2.7.0",
 			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.0",
-				"maxChannelServerVersion": "v2.10.0",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.7.0 < min < max < 2.10.0",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.7.2-alpha1",
-				"maxChannelServerVersion": "v2.9.14-patch1",
-				"version":                 "v1.20.15+rke2r2"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "2.11.0 < min < 2.11.99 < max",
-			args: args{release: map[string]interface{}{
-				"minChannelServerVersion": "v2.11.1-alpha1",
-				"maxChannelServerVersion": "v2.12.0-patch1",
+				"minChannelServerVersion": "v2.6.12-alpha1",
+				"maxChannelServerVersion": "v2.6.14",
 				"version":                 "v1.20.15+rke2r2"},
 			},
 			want:    false,


### PR DESCRIPTION
We don't need this because we won't versions that are only supported by more recent Rancher versions, and we could miss images if we add a k8s release that has a min version > 2.11.0-alpha1.