### PR TITLE
hotfix: manually set CATTLE_AGENT_IMAGE for 2.12 branch

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -98,4 +98,11 @@ cd "$RANCHER_DIR"
 # Remove superfluous check for UI only bumps in this context
 sed -i -e '3,5d' ./scripts/provisioning-tests
 
+# setting the agent image to the last community version manually for now,
+# this will be fixed when https://github.com/rancher/kontainer-driver-metadata/pull/1838 merges
+export CATTLE_AGENT_IMAGE=rancher/rancher-agent:v2.12.2
+
+# pulling the image into the local docker daemon to be pushed into the registry-cache when tests run
+docker pull -q rancher/rancher-agent:v2.12.2
+
 ./scripts/provisioning-tests


### PR DESCRIPTION
This is for the November patches - it looks like the Agent Image is being set to 2.12.4 which doesn't exist in dockerhub.