### PR TITLE
Adjust maxChannelServerVersion for 2.14

### DIFF
--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         dist: [rke2, k3s]
-        k8s-minor: [32, 33, 34]
+        k8s-minor: [33, 34]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
     steps:
       - name: Force Install GIT latest

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,8 +1,8 @@
-ARG RANCHER_VERSION=v2.13-head
+ARG RANCHER_VERSION=head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.24
+FROM registry.suse.com/bci/golang:1.25
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -28,6 +28,8 @@ appDefaults:
         defaultVersion: '1.33.x'
       - appVersion: '>= 2.13.0-0 < 2.14.100-0'
         defaultVersion: '1.34.x'
+      - appVersion: '>= 2.14.0-0 < 2.15.100-0'
+        defaultVersion: '1.34.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
@@ -4071,7 +4073,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.0+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v1-31-0-rke2r1
     agentArgs: *agentArgs-v1-28-11-rke2r1
     charts: &charts-v1-33-0-rke2r1
@@ -4086,7 +4088,7 @@ releases:
         # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.33.1+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-1-rke2r1
       <<: *charts-v1-33-0-rke2r1
       rke2-canal:
@@ -4126,7 +4128,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.2+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-2-rke2r1
       <<: *chartsv1-33-1-rke2r1
       rke2-calico:
@@ -4163,7 +4165,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.3+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-3-rke2r1
       <<: *chartsv1-33-2-rke2r1
       rke2-flannel:
@@ -4200,7 +4202,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.4+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-4-rke2r1
       <<: *chartsv1-33-3-rke2r1
       rke2-cilium:
@@ -4237,7 +4239,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.5+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-5-rke2r1
       <<: *chartsv1-33-4-rke2r1
       rke2-ingress-nginx:
@@ -4302,7 +4304,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.6+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-33-6-rke2r1
       <<: *chartsv1-33-5-rke2r1
       rke2-calico-crd:
@@ -4351,7 +4353,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.1+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-34-1-rke2r1
       <<: *chartsv1-33-3-rke2r1
       rancher-vsphere-cpi:
@@ -4416,7 +4418,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.2+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     charts: &chartsv1-34-2-rke2r1
       <<: *chartsv1-34-1-rke2r1
       rke2-calico-crd:

--- a/channels.yaml
+++ b/channels.yaml
@@ -28,6 +28,8 @@ appDefaults:
         defaultVersion: '1.33.x' 
       - appVersion: '>= 2.13.0-0 < 2.14.100-0'
         defaultVersion: '1.34.x' 
+      - appVersion: '>= 2.14.0-0 < 2.15.100-0'
+        defaultVersion: '1.34.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1
@@ -1002,7 +1004,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.0+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: &serverArgs-v11
       <<: *serverArgs-v10
       secrets-encryption-provider:
@@ -1016,31 +1018,31 @@ releases:
     # featureVersions field is intentionally not defined to disable encryption key rotation for April 2025 patches due to https://github.com/rancher/rke2/issues/8236
   - version: v1.33.1+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.2+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.3+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.4+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v11
     agentArgs: *agentArgs-v7
     featureVersions: *featureVersions-v1
   - version: v1.33.5+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: &serverArgs-v13 # this was needed since the older secrets-encryption-provider is present in v1.32.x and v1.31.x patches
       <<: *serverArgs-v12
       secrets-encryption-provider:
@@ -1053,19 +1055,19 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.33.6+k3s1
     minChannelServerVersion: v2.12.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.1+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.2+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.13.99
+    maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -61,6 +61,10 @@
      {
       "appVersion": "\u003e= 2.13.0-0 \u003c 2.14.100-0",
       "defaultVersion": "1.34.x"
+     },
+     {
+      "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
+      "defaultVersion": "1.34.x"
      }
     ]
    }
@@ -23734,7 +23738,7 @@
       "type": "string"
      }
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -23946,7 +23950,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -24158,7 +24162,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -24370,7 +24374,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -24582,7 +24586,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -24812,7 +24816,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -25057,7 +25061,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -25302,7 +25306,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -25547,7 +25551,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -25755,6 +25759,10 @@
      },
      {
       "appVersion": "\u003e= 2.13.0-0 \u003c 2.14.100-0",
+      "defaultVersion": "1.34.x"
+     },
+     {
+      "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
       "defaultVersion": "1.34.x"
      }
     ]
@@ -64550,7 +64558,7 @@
       "version": "34.2.002"
      }
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -64879,7 +64887,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -65208,7 +65216,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -65537,7 +65545,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -65866,7 +65874,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -66219,7 +66227,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -66581,7 +66589,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.12.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -66943,7 +66951,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -67305,7 +67313,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.13.99",
+    "maxChannelServerVersion": "v2.14.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {

--- a/scripts/fetch-provisioning-tests
+++ b/scripts/fetch-provisioning-tests
@@ -12,7 +12,7 @@ TMP_DIR=$(mktemp -d)
 pushd "$TMP_DIR"
 
 IMAGE_REPO=${IMAGE_REPO:-rancher/rancher}
-IMAGE_TAG=${IMAGE_TAG:-v2.13-head}
+IMAGE_TAG=${IMAGE_TAG:-head}
 IMAGE=${IMAGE:-$IMAGE_REPO:$IMAGE_TAG}
 
 # Inspect image, get server version and extract rancher commit 
@@ -29,7 +29,7 @@ mkdir -p rancher
 # Although using the commit so the image matches the source code, use the default branch associated with that release line
 # Git clones must have a branch, and the release branch is likely to contain the commit anyway
 GIT_URL=${GIT_URL:-https://github.com/rancher/rancher.git}
-GIT_BRANCH=${GIT_BRANCH:-release/v2.13}
+GIT_BRANCH=${GIT_BRANCH:-main}
 
 git clone --depth 1 -b $GIT_BRANCH $GIT_URL ./rancher
 


### PR DESCRIPTION
Also adds appDefaults for 2.14, temporarily set to 1.34.x until 1.35.0 is released, at which point it should be changed.