### PR TITLE
[2.14] add k8s minor version 1.35 to provisioning-tests matrix + move execution inline with r/r

### DIFF
--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -18,11 +18,7 @@ jobs:
       - runs-on
       - spot=false
       - runner=4cpu-linux-x64
-      - image=legacy-cgroups-for-x64
       - run-id=${{ github.run_id }}
-    container:
-      image: rancher/dapper:v0.6.0
-      options: --privileged
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -30,19 +26,29 @@ jobs:
         dist: [rke2, k3s]
         k8s-minor: [33, 34, 35]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
+    env:
+      # this is due to the dapper pod having a host-port on the registry-cache container
+      # we can hit this registry from dapper OR the host docker if we use the docker IP
+      REGISTRY: "172.17.0.2:5000"
     steps:
-      - name: Force Install GIT latest
-        run: |
-          apk add git --update-cache
-          git --version
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: "0"
+      - name: testdata
+        run: mkdir -p build/testdata
+      - name: Install Dapper
+        run: |
+          curl -sL https://releases.rancher.com/dapper/latest/dapper-$(uname -s)-$(uname -m) > ./.dapper
+          chmod +x ./.dapper
+      - name: Configure Docker for cgroupfs/insecure-registry
+        run: |
+          echo '{"insecure-registries": ["172.17.0.2:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          sudo docker info
       - name: Provisioning Operations tests
         run: |
-          dapper provisioning-tests
+          ./.dapper provisioning-tests
         env:
           V2PROV_TEST_DIST: ${{ matrix.dist }}
           V2PROV_TEST_RUN_REGEX: ${{ matrix.test-regex }}

--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         dist: [rke2, k3s]
-        k8s-minor: [33, 34]
+        k8s-minor: [33, 34, 35]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
     steps:
       - name: Force Install GIT latest


### PR DESCRIPTION
This way changes are tested against the next k8s minor version. This also updates the GH workflow to run the provisioning tests exactly the same as r/r - instead of running them in a dapper container directly.