### PR TITLE
fix minChannelServerVersion for v1.35.x

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -29,7 +29,7 @@ appDefaults:
       - appVersion: '>= 2.13.0-0 < 2.14.100-0'
         defaultVersion: '1.34.x'
       - appVersion: '>= 2.14.0-0 < 2.15.100-0'
-        defaultVersion: '1.34.x'
+        defaultVersion: '1.35.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
@@ -4751,7 +4751,7 @@ releases:
       <<: *agentArgsv1-34-3-rke2r1
     featureVersions: *featureVersions-v1
   - version: v1.35.0+rke2r1
-    minChannelServerVersion: v2.13.0-alpha1
+    minChannelServerVersion: v2.14.0-alpha1
     maxChannelServerVersion: v2.14.99
     charts: &chartsv1-35-0-rke2r1
       <<: *chartsv1-34-2-rke2r1
@@ -4800,7 +4800,7 @@ releases:
       <<: *agentArgsv1-34-2-rke2r1
     featureVersions: *featureVersions-v1
   - version: v1.35.0+rke2r3
-    minChannelServerVersion: v2.13.0-alpha1
+    minChannelServerVersion: v2.14.0-alpha1
     maxChannelServerVersion: v2.14.99
     charts: &chartsv1-35-0-rke2r3
       <<: *chartsv1-35-0-rke2r1

--- a/channels.yaml
+++ b/channels.yaml
@@ -29,7 +29,7 @@ appDefaults:
       - appVersion: '>= 2.13.0-0 < 2.14.100-0'
         defaultVersion: '1.34.x' 
       - appVersion: '>= 2.14.0-0 < 2.15.100-0'
-        defaultVersion: '1.34.x'
+        defaultVersion: '1.35.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1
@@ -1126,19 +1126,19 @@ releases:
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.0+k3s1
-    minChannelServerVersion: v2.13.0-alpha1
+    minChannelServerVersion: v2.14.0-alpha1
     maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.0+k3s3
-    minChannelServerVersion: v2.13.0-alpha1
+    minChannelServerVersion: v2.14.0-alpha1
     maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.1+k3s1
-    minChannelServerVersion: v2.13.0-alpha1
+    minChannelServerVersion: v2.14.0-alpha1
     maxChannelServerVersion: v2.14.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8

--- a/data/data.json
+++ b/data/data.json
@@ -64,7 +64,7 @@
      },
      {
       "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
-      "defaultVersion": "1.34.x"
+      "defaultVersion": "1.35.x"
      }
     ]
    }
@@ -27987,7 +27987,7 @@
      "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.14.99",
-    "minChannelServerVersion": "v2.13.0-alpha1",
+    "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
       "type": "string"
@@ -28232,7 +28232,7 @@
      "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.14.99",
-    "minChannelServerVersion": "v2.13.0-alpha1",
+    "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
       "type": "string"
@@ -28477,7 +28477,7 @@
      "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.14.99",
-    "minChannelServerVersion": "v2.13.0-alpha1",
+    "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
       "type": "string"
@@ -28688,7 +28688,7 @@
      },
      {
       "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
-      "defaultVersion": "1.34.x"
+      "defaultVersion": "1.35.x"
      }
     ]
    }
@@ -72773,7 +72773,7 @@
      "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.14.99",
-    "minChannelServerVersion": "v2.13.0-alpha1",
+    "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
       "type": "string"
@@ -73135,7 +73135,7 @@
      "encryption-key-rotation": "2.0.0"
     },
     "maxChannelServerVersion": "v2.14.99",
-    "minChannelServerVersion": "v2.13.0-alpha1",
+    "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
       "type": "string"


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/52957

### Why this change was needed?
GitHub Actions runners recently upgraded the Docker daemon to a newer version, which caused incompatibility with the older Docker CLI present inside the dapper container. This resulted in client–daemon communication errors and CI test failures. Upgrading the Docker CLI ensures compatibility and restores CI stability.

**Error**
`client version 1.40 is too old. Minimum supported API version is 1.44`

**Fix:**
`.github/workflows/workflow.yaml`

- Added Docker CLI upgrade step to version 29.2.1
`
- name: Upgrade Docker CLI
  run: |
    DOCKER_VERSION="29.2.1"
    wget "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" -O docker.tgz
    tar -xzvf docker.tgz docker/docker --strip-components=1
    mv docker /usr/local/bin/docker
    docker version
`