### PR TITLE
[dev-v2.13] hardcode to v2.13-head for CATTLE_AGENT_IMAGE

### DIFF
--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -18,11 +18,7 @@ jobs:
       - runs-on
       - spot=false
       - runner=4cpu-linux-x64
-      - image=legacy-cgroups-for-x64
       - run-id=${{ github.run_id }}
-    container:
-      image: rancher/dapper:v0.6.0
-      options: --privileged
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -31,21 +27,28 @@ jobs:
         k8s-minor: [32, 33, 34]
         test-regex: ["^Test_Provisioning_.*$", "^Test_Operation_SetA_.*$", "^Test_Operation_SetB_.*$"]
     steps:
-      - name: Force Install GIT latest
-        run: |
-          apk add git --update-cache
-          git --version
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+      - name: testdata
+        run: mkdir -p build/testdata
+      - name: Install Dapper
+        run: |
+          curl -sL https://releases.rancher.com/dapper/latest/dapper-$(uname -s)-$(uname -m) > ./.dapper
+          chmod +x ./.dapper
+      - name: Configure Docker for cgroupfs/insecure-registry
+        run: |
+          echo '{"insecure-registries": ["172.17.0.2:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          sudo docker info
       - name: Provisioning Operations tests
         run: |
-          dapper provisioning-tests
+          ./.dapper provisioning-tests
         env:
           V2PROV_TEST_DIST: ${{ matrix.dist }}
           V2PROV_TEST_RUN_REGEX: ${{ matrix.test-regex }}
           KDM_TEST_K8S_MINOR: ${{ matrix.k8s-minor }}
           PREV_COMMIT_PR_SHA: ${{ github.event.pull_request.base.sha }}
           PREV_COMMIT_PUSH_SHA: ${{ github.event.before }}
+          CATTLE_AGENT_IMAGE: v2.13-head

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,7 +1,7 @@
 name: Main workflow
 
 on:
-  push: 
+  push:
     branches:
       - 'dev-v*'
       - 'release-v*'
@@ -17,16 +17,15 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    container: 
-      image: rancher/dapper:v0.6.0
     steps:
-      - name: Force Install GIT latest
-        run: |
-          apk add git --update-cache
-          git --version
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install Dapper
+        run: |
+          curl -sL https://releases.rancher.com/dapper/v0.6.0/dapper-$(uname -s)-$(uname -m) > /usr/local/bin/dapper
+          chmod +x /usr/local/bin/dapper
+
       - name: Validate
         run: dapper ci
 
@@ -36,7 +35,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     needs: validate
-    container: 
+    container:
       image: rancher/dapper:v0.6.0
     if: github.event_name == 'push' && startsWith(github.ref_name, 'release-v')
     steps:

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -98,4 +98,5 @@ cd "$RANCHER_DIR"
 # Remove superfluous check for UI only bumps in this context
 sed -i -e '3,5d' ./scripts/provisioning-tests
 
+export CATTLE_AGENT_IMAGE=${CATTLE_AGENT_IMAGE:-rancher/rancher-agent:v2.13-head}
 ./scripts/provisioning-tests


### PR DESCRIPTION
this is due to the fact we removed a feature flag (embedded-cluster-api) on `:head`, which was causing failures in the cluster-agent to start up.