### PR TITLE
[dev-v2.14] Add node-name-from-cloud-provider-metadata argument

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -4212,8 +4212,12 @@ releases:
   - version: v1.33.0+rke2r1
     minChannelServerVersion: v2.12.0-alpha1
     maxChannelServerVersion: v2.14.99
-    serverArgs: *serverArgs-v1-31-0-rke2r1
-    agentArgs: *agentArgs-v1-28-11-rke2r1
+    serverArgs: &serverArgsv1-33-0-rke2r1
+      <<: *serverArgs-v1-31-0-rke2r1
+    agentArgs: &agentArgsv1-33-0-rke2r1
+      <<: *agentArgs-v1-28-11-rke2r1
+      node-name-from-cloud-provider-metadata:
+        type: boolean
     charts: &charts-v1-33-0-rke2r1
       <<: *charts-v1-32-4-rke2r1
       rancher-vsphere-cpi:
@@ -4260,9 +4264,9 @@ releases:
         repo: rancher-rke2-charts
         version: 1.42.000
     serverArgs: &serverArgsv1-33-1-rke2r1
-      <<: *serverArgs-v1-31-0-rke2r1
+      <<: *serverArgsv1-33-0-rke2r1
     agentArgs: &agentArgsv1-33-1-rke2r1
-      <<: *agentArgs-v1-28-11-rke2r1
+      <<: *agentArgsv1-33-0-rke2r1
     featureVersions: *featureVersions-v1
   - version: v1.33.2+rke2r1
     minChannelServerVersion: v2.12.0-alpha1

--- a/data/data.json
+++ b/data/data.json
@@ -68469,6 +68469,9 @@
      "kubelet-arg": {
       "type": "array"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "profile": {
       "nullable": true,
       "options": [
@@ -68794,6 +68797,9 @@
      },
      "kubelet-arg": {
       "type": "array"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "profile": {
       "nullable": true,
@@ -69124,6 +69130,9 @@
      "kubelet-arg": {
       "type": "array"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "profile": {
       "nullable": true,
       "options": [
@@ -69453,6 +69462,9 @@
      "kubelet-arg": {
       "type": "array"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "profile": {
       "nullable": true,
       "options": [
@@ -69781,6 +69793,9 @@
      },
      "kubelet-arg": {
       "type": "array"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "profile": {
       "nullable": true,
@@ -70128,6 +70143,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -70491,6 +70509,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -70852,6 +70873,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -71215,6 +71239,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -71576,6 +71603,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -71939,6 +71969,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -72300,6 +72333,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -72663,6 +72699,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -73024,6 +73063,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -73387,6 +73429,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -73748,6 +73793,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"
@@ -74111,6 +74159,9 @@
      "lb-server-port": {
       "type": "string"
      },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
+     },
      "nonroot-devices": {
       "type": "boolean"
      },
@@ -74472,6 +74523,9 @@
      },
      "lb-server-port": {
       "type": "string"
+     },
+     "node-name-from-cloud-provider-metadata": {
+      "type": "boolean"
      },
      "nonroot-devices": {
       "type": "boolean"


### PR DESCRIPTION
Add the `node-name-from-cloud-provider-metadata` to help configure the AWS cloud controllers in some situations.

Tested by provisioning a cluster with this argument and the aws cloud controller. The `providerID` was correctly set in the downstream node and the new argument appeared in `/etc/rancher/rke2/config.yaml.d/50-rancher.yaml`.

Issue: https://github.com/rancher/rancher/issues/53852

QA Suggestions:

- Create an rke2 cluster on ec2 through Rancher with the following configs:
  -  `node-name-from-cloud-provider-metadata: true` (in `machineGlobalConfig`)
  - The AWS cloud controller chart as an additional manifest

The cluster doesn't have to be an experimental one that uses CAPA, it can be a regular node driver AWS cluster.
 
Then check that the argument was passed correctly in `/etc/rancher/rke2/config.yaml.d/50-rancher.yaml`.

Each node should also have a name that matches the private dns name from IMDS (something like `ip-0-0-0-0.ec2.internal`). The `providerID` ind the node `spec.` should also be set to something like `aws://` if the cloud controller worked.

The cluster should come up ok.