### PR TITLE
[v2.11] update go to 1.25

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.11-head
 
 FROM rancher/rancher:$RANCHER_VERSION as rancher
 
-FROM registry.suse.com/bci/golang:1.24
+FROM registry.suse.com/bci/golang:1.25
 
 RUN mkdir -p /var/lib/rancher
 COPY --from=rancher /var/lib/rancher /var/lib/rancher
@@ -64,7 +64,7 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV GOLANGCI_LINT v1.64.8
+ENV GOLANGCI_LINT v1.65.1
 
 RUN zypper -n install git docker vim less file curl wget jq awk ruby && rpm -e --nodeps --noscripts containerd
 RUN go install golang.org/x/tools/cmd/goimports@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/kontainer-driver-metadata
 
-go 1.24
+go 1.25
 
 replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e


### PR DESCRIPTION
Updating Go to fix CI failures like:
```
#11 [stage-1 12/15] RUN go install golang.org/x/tools/cmd/goimports@latest
#11 0.204 go: downloading golang.org/x/tools v0.43.0
#11 0.441 go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.43.0 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```