### PR TITLE
Prevent provisioning test workflow failure when artifacts are missing

### DIFF
--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -8,17 +8,29 @@ permissions: {}
 
 jobs:
   publish-provisioning-test-results:
-    runs-on: runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
+    container: registry.suse.com/bci/bci-base:15.7
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     permissions:
       checks: write
       pull-requests: write
       actions: read
     steps:
+	  - name: Install Python Deps
+		run: |
+		  # install python
+		  zypper --non-interactive install python311 python311-pip python311-virtualenv which
+
+		  # set python as the default python (essentially just a symlink)
+		  update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+
       - name: mkdir test-results
         run: mkdir -p /tmp/test-results
 
       - name: Download All XML Test Reports
+        id: xml_reports
+        # don't error the entire job if the artifact is not there
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -29,6 +41,9 @@ jobs:
           name: "XML Results"
 
       - name: Download the Event File
+        id: event_file
+        continue-on-error: true
+        if: steps.xml_reports.outcome == 'success'
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -39,7 +54,7 @@ jobs:
 
       - name: Publish Test Results
         uses: rancher/publish-unit-test-result-action/linux@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6
-        if: (!cancelled())
+        if: steps.xml_reports.outcome == 'success' && steps.event_file.outcome == 'success'
         with:
           check_name: Provisioning Tests Results
           commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Problem

This PR updates the `publish-provisioning-test-results` workflow to gracefully handle missing artifacts and prevent misleading job failures.

Currently, if a workflow run doesn't generate the expected XML test reports or event files, the `actions/download-artifact` step hard-fails the entire job. This creates a false-failure scenario where the job appears broken (red), even though the failure is simply due to an absence of test results to publish.

## Solution

* Added `continue-on-error: true` to the artifact download steps so the workflow survives a missing file.
* Assigned step IDs (`xml_reports`, `event_file`) to capture the download execution status.
* Added conditional logic (`if: steps.<id>.outcome == 'success'`) to ensure we only attempt to download the event file and run the `publish-unit-test-result-action` step if the prerequisite artifacts were actually found.


I also updated this workflow to be in-line with r/r and run on the EIO k8s cluster rather than a regular runner to save some $$$$.

---

Sidenote: there will still be red steps but the entire job won't result in a failure (e.g. an email). Copilot said the only way to really check and see if an artifact exists and handle it is by using `gh` like this which is a little more yucky:

```yaml
- name: Download artifact gracefully via CLI
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: |
      # Attempt to download; if it fails, echo a message instead of failing the step
      if gh run download ${{ github.run_id }} -n "XML Results" ; then
        echo "Artifact downloaded successfully."
      else
        echo "Artifact not found, skipping."
      fi
```
