### PR TITLE
[dev-v2.12] fix gha syntax

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -70,7 +70,7 @@ jobs:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/google-auth/rancher/credentials token | GOOGLE_AUTH ;
       - name: Authenticate with Google Cloud
-        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2'
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: '${{ env.GOOGLE_AUTH }}'
       - name: Upload to Google Cloud Storage


### PR DESCRIPTION
Fix the problem that the `# v2` comment is inside the quoted string, which causes GHA to fail to find the target version.