### PR TITLE
[dev-2.15] updates for v2.15 branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranchPatterns": [
+    "dev-v2.15",
     "dev-v2.14",
     "dev-v2.13",
     "dev-v2.12",

--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -115,13 +115,13 @@ jobs:
             --env STAGE_REGISTRY_ENDPOINT \
             kdm-ci provisioning-tests | tee ./build/provtest_output.txt
         env:
-          LAST_COMMUNITY_RANCHER: v2.14.99
+          LAST_COMMUNITY_RANCHER: v2.15.99
           V2PROV_TEST_DIST: ${{ matrix.dist }}
           V2PROV_TEST_RUN_REGEX: ${{ matrix.test-regex }}
           KDM_TEST_K8S_MINOR: ${{ matrix.k8s-minor }}
           PREV_COMMIT_PR_SHA: ${{ github.event.pull_request.base.sha }}
           PREV_COMMIT_PUSH_SHA: ${{ github.event.before }}
-          CATTLE_AGENT_IMAGE: "rancher/rancher-agent:v2.14-head"
+          CATTLE_AGENT_IMAGE: "rancher/rancher-agent:head" # TODO: change to v2.15-head after v2.15.0 is released
       - name: Move plaintext test results for upload
         if: always()
         id: test_output

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -30,6 +30,8 @@ appDefaults:
         defaultVersion: '1.34.x'
       - appVersion: '>= 2.14.0-0 < 2.15.100-0'
         defaultVersion: '1.35.x'
+      - appVersion: '>= 2.15.0-0 < 2.16.100-0'
+        defaultVersion: '1.35.x'
 releases:
   - version: v1.19.16+rke2r1
     minChannelServerVersion: v2.6.0-alpha1
@@ -4736,7 +4738,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.1+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-1-rke2r1
       <<: *chartsv1-33-3-rke2r1
       rancher-vsphere-cpi:
@@ -4801,7 +4803,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.2+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-2-rke2r1
       <<: *chartsv1-34-1-rke2r1
       rke2-calico-crd:
@@ -4850,7 +4852,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.3+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-3-rke2r1
       <<: *chartsv1-34-2-rke2r1
       rke2-canal:
@@ -4896,7 +4898,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.3+rke2r3
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-3-rke2r3
       <<: *chartsv1-34-3-rke2r1
       rke2-calico:
@@ -4945,7 +4947,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.4+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-4-rke2r1
       <<: *chartsv1-34-3-rke2r3
       rke2-traefik-crd:
@@ -4988,7 +4990,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.5+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-5-rke2r1
       <<: *chartsv1-34-4-rke2r1
       rke2-cilium:
@@ -5010,7 +5012,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.6+rke2r1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-6-rke2r1
       <<: *chartsv1-34-5-rke2r1
       rke2-cilium:
@@ -5056,7 +5058,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.6+rke2r3
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-34-6-rke2r3
       <<: *chartsv1-34-6-rke2r1
       rke2-ingress-nginx:
@@ -5069,7 +5071,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.0+rke2r1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-0-rke2r1
       <<: *chartsv1-34-2-rke2r1
       rancher-vsphere-cpi:
@@ -5118,7 +5120,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.0+rke2r3
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-0-rke2r3
       <<: *chartsv1-35-0-rke2r1
       rke2-calico:
@@ -5167,7 +5169,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.1+rke2r1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-1-rke2r1
       <<: *chartsv1-35-0-rke2r3
       rke2-canal:
@@ -5210,7 +5212,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.2+rke2r1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-2-rke2r1
       <<: *chartsv1-35-1-rke2r1
       rke2-cilium:
@@ -5232,7 +5234,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.3+rke2r1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-3-rke2r1
       <<: *chartsv1-35-2-rke2r1
       rke2-traefik:
@@ -5278,7 +5280,7 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.35.3+rke2r3
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     charts: &chartsv1-35-3-rke2r3
       <<: *chartsv1-35-3-rke2r1
       rke2-ingress-nginx:

--- a/channels.yaml
+++ b/channels.yaml
@@ -30,6 +30,8 @@ appDefaults:
         defaultVersion: '1.34.x' 
       - appVersion: '>= 2.14.0-0 < 2.15.100-0'
         defaultVersion: '1.35.x'
+      - appVersion: '>= 2.15.0-0 < 2.16.100-0'
+        defaultVersion: '1.35.x'
 releases:
   - version: v1.18.20+k3s1
     minChannelServerVersion: v2.6.0-alpha1
@@ -1115,73 +1117,73 @@ releases:
     featureVersions: *featureVersions-v1
   - version: v1.34.1+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.2+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.3+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.3+k3s3
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.4+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.5+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.34.6+k3s1
     minChannelServerVersion: v2.13.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.0+k3s1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.0+k3s3
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.1+k3s1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.2+k3s1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1
   - version: v1.35.3+k3s1
     minChannelServerVersion: v2.14.0-alpha1
-    maxChannelServerVersion: v2.14.99
+    maxChannelServerVersion: v2.15.99
     serverArgs: *serverArgs-v13
     agentArgs: *agentArgs-v8
     featureVersions: *featureVersions-v1

--- a/data/data.json
+++ b/data/data.json
@@ -65,6 +65,10 @@
      {
       "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
       "defaultVersion": "1.35.x"
+     },
+     {
+      "appVersion": "\u003e= 2.15.0-0 \u003c 2.16.100-0",
+      "defaultVersion": "1.35.x"
      }
     ]
    }
@@ -27491,7 +27495,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -27736,7 +27740,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -27981,7 +27985,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -28226,7 +28230,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -28471,7 +28475,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -28716,7 +28720,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -28961,7 +28965,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -29206,7 +29210,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -29451,7 +29455,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -29696,7 +29700,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -29941,7 +29945,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -30186,7 +30190,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "cluster-cidr": {
@@ -30398,6 +30402,10 @@
      },
      {
       "appVersion": "\u003e= 2.14.0-0 \u003c 2.15.100-0",
+      "defaultVersion": "1.35.x"
+     },
+     {
+      "appVersion": "\u003e= 2.15.0-0 \u003c 2.16.100-0",
       "defaultVersion": "1.35.x"
      }
     ]
@@ -75248,7 +75256,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -75613,7 +75621,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -75978,7 +75986,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -76343,7 +76351,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -76708,7 +76716,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -77073,7 +77081,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -77438,7 +77446,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -77803,7 +77811,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.13.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -78168,7 +78176,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -78533,7 +78541,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -78898,7 +78906,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -79263,7 +79271,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -79628,7 +79636,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {
@@ -79993,7 +80001,7 @@
     "featureVersions": {
      "encryption-key-rotation": "2.0.0"
     },
-    "maxChannelServerVersion": "v2.14.99",
+    "maxChannelServerVersion": "v2.15.99",
     "minChannelServerVersion": "v2.14.0-alpha1",
     "serverArgs": {
      "audit-policy-file": {


### PR DESCRIPTION
- updated maxChannelServerVersion for 1.34.x and 1.35.x to `2.15.99` 
- skipped adding `packageRules` entry in renovate.json since `rancher-2.15#release` config doesn't exist in  rancher/renovate-config yet                                                      