### PR TITLE
Update go to 1.26

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@ ARG RANCHER_VERSION=v2.15-head
 
 FROM rancher/rancher:$RANCHER_VERSION AS rancher
 
-FROM registry.suse.com/bci/golang:1.25
+FROM registry.suse.com/bci/golang:1.26
 
 # --- Tool installations (most expensive, no dependency on rancher content) ---
 ARG TARGETARCH=amd64


### PR DESCRIPTION
We are now using provisioning tests from Rancher 2.15, which requires go 1.26 to compile Rancher to run it, so this PR updates the toolchain in the CI image (it seems that registry.suse.com/bci/golang uses `GOOLTOOLCHAIN=local` so it won't automatically download the require toolchain).