### PR TITLE
Add agentRestart flag to disable-kube-proxy serverArg

### DIFF
--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -69,6 +69,7 @@ releases:
       disable-kube-proxy:
         type: boolean
         default: false
+        agentRestart: true
       cluster-cidr:
         type: string
       audit-policy-file:

--- a/channels-rke2.yaml
+++ b/channels-rke2.yaml
@@ -49,6 +49,7 @@ releases:
         type: array
       cluster-dns:
         type: string
+        agentRestart: true
       service-cidr:
         type: string
       kube-controller-manager-arg:
@@ -69,14 +70,17 @@ releases:
       disable-kube-proxy:
         type: boolean
         default: false
+        agentRestart: true
       cluster-cidr:
         type: string
       audit-policy-file:
         type: string
       service-node-port-range:
         type: string
+        agentRestart: true
       cluster-domain:
         type: string
+        agentRestart: true
       cni:
         default: calico
         type: array
@@ -134,6 +138,7 @@ releases:
         type: string
       system-default-registry:
         type: string
+        agentRestart: true
       protect-kernel-defaults:
         type: boolean
         default: false
@@ -574,6 +579,7 @@ releases:
       <<: *serverArgs-v1-22-9-rke2r2
       egress-selector-mode:
         type: string
+        agentRestart: true
     agentArgs: &agentArgs-v1-22-10-rke2r2
       <<: *agentArgs-v1-22-9-rke2r2
     charts: &charts-v1-22-10-rke2r2
@@ -743,6 +749,7 @@ releases:
       <<: *serverArgs-v1-23-6-rke2r2
       egress-selector-mode:
         type: string
+        agentRestart: true
     agentArgs: &agentArgs-v1-23-7-rke2r2
       <<: *agentArgs-v1-23-6-rke2r2
     charts: &charts-v1-23-7-rke2r2
@@ -1936,6 +1943,7 @@ releases:
       <<: *serverArgs-v1-27-13-rke2r1
       supervisor-metrics:
         type: boolean
+        agentRestart: true
       write-kubeconfig-group:
         type: string
     agentArgs: &agentArgs-v1-27-15-rke2r1
@@ -2012,6 +2020,7 @@ releases:
       <<: *serverArgs-v1-27-11-rke2r1
       embedded-registry:
         type: boolean
+        agentRestart: true
     agentArgs: &agentArgs-v1-28-8-rke2r1
       <<: *agentArgs-v1-25-15-rke2r2
       default-runtime:
@@ -2098,6 +2107,7 @@ releases:
       <<: *serverArgs-v1-28-9-rke2r1
       supervisor-metrics:
         type: boolean
+        agentRestart: true
       write-kubeconfig-group:
         type: string
     agentArgs: &agentArgs-v1-28-11-rke2r1

--- a/data/data.json
+++ b/data/data.json
@@ -35115,6 +35115,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35359,6 +35360,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35603,6 +35605,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35847,6 +35850,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36091,6 +36095,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36338,6 +36343,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36585,6 +36591,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36832,6 +36839,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37079,6 +37087,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37326,6 +37335,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37573,6 +37583,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37823,6 +37834,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38070,6 +38082,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38317,6 +38330,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38564,6 +38578,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38811,6 +38826,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39058,6 +39074,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39305,6 +39322,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39552,6 +39570,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39805,6 +39824,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40058,6 +40078,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40311,6 +40332,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40564,6 +40586,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40814,6 +40837,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41061,6 +41085,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41311,6 +41336,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41558,6 +41584,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41805,6 +41832,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42058,6 +42086,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42311,6 +42340,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42561,6 +42591,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42814,6 +42845,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43067,6 +43099,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43320,6 +43353,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43573,6 +43607,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43826,6 +43861,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44079,6 +44115,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44332,6 +44369,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44585,6 +44623,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44838,6 +44877,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45091,6 +45131,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45344,6 +45385,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45597,6 +45639,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45850,6 +45893,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46103,6 +46147,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46356,6 +46401,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46620,6 +46666,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46873,6 +46920,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47140,6 +47188,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47404,6 +47453,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47668,6 +47718,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47932,6 +47983,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48196,6 +48248,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48464,6 +48517,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48735,6 +48789,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49005,6 +49060,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49269,6 +49325,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49533,6 +49590,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49797,6 +49855,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50065,6 +50124,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50336,6 +50396,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50607,6 +50668,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50879,6 +50941,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51151,6 +51214,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51421,6 +51485,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51689,6 +51754,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51960,6 +52026,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52231,6 +52298,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52503,6 +52571,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52775,6 +52844,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53063,6 +53133,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53351,6 +53422,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53645,6 +53717,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53945,6 +54018,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54245,6 +54319,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54529,6 +54604,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54826,6 +54902,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55123,6 +55200,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55426,6 +55504,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55735,6 +55814,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56052,6 +56132,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56369,6 +56450,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56686,6 +56768,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56981,6 +57064,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57278,6 +57362,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57575,6 +57660,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57872,6 +57958,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58169,6 +58256,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58474,6 +58562,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58779,6 +58868,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59084,6 +59174,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59389,6 +59480,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59694,6 +59786,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60003,6 +60096,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60312,6 +60406,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60621,6 +60716,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60926,6 +61022,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61229,6 +61326,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61546,6 +61644,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61871,6 +61970,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62196,6 +62296,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62521,6 +62622,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62846,6 +62948,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63171,6 +63274,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63500,6 +63604,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63829,6 +63934,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64158,6 +64264,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64484,6 +64591,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64813,6 +64921,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65142,6 +65251,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65471,6 +65581,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65796,6 +65907,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66121,6 +66233,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66446,6 +66559,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66771,6 +66885,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67096,6 +67211,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67425,6 +67541,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67754,6 +67871,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68083,6 +68201,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68409,6 +68528,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68738,6 +68858,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69067,6 +69188,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69396,6 +69518,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69725,6 +69848,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70078,6 +70202,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70422,6 +70547,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70751,6 +70877,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71080,6 +71207,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71406,6 +71534,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71735,6 +71864,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72064,6 +72194,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72393,6 +72524,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72722,6 +72854,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73075,6 +73208,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73443,6 +73577,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73811,6 +73946,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74179,6 +74315,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74547,6 +74684,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74915,6 +75053,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75259,6 +75398,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75591,6 +75731,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75923,6 +76064,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76255,6 +76397,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76587,6 +76730,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76943,6 +77087,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -77314,6 +77459,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -77685,6 +77831,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78056,6 +78203,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78427,6 +78575,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78798,6 +78947,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79169,6 +79319,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79543,6 +79694,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79917,6 +80069,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -80291,6 +80444,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -80665,6 +80819,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81039,6 +81194,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81416,6 +81572,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81787,6 +81944,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82158,6 +82316,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82529,6 +82688,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82900,6 +83060,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -83271,6 +83432,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -83642,6 +83804,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84016,6 +84179,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84390,6 +84554,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84764,6 +84929,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85138,6 +85304,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85512,6 +85679,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85889,6 +86057,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -86260,6 +86429,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -86631,6 +86801,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87002,6 +87173,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87373,6 +87545,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87747,6 +87920,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88121,6 +88295,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88495,6 +88670,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88869,6 +89045,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -89243,6 +89420,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -89624,6 +89802,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -90002,6 +90181,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -90380,6 +90560,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },

--- a/data/data.json
+++ b/data/data.json
@@ -35028,6 +35028,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -35083,9 +35084,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -35115,6 +35118,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35162,6 +35166,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -35264,6 +35269,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -35327,9 +35333,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -35359,6 +35367,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35406,6 +35415,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -35508,6 +35518,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -35571,9 +35582,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -35603,6 +35616,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35650,6 +35664,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -35752,6 +35767,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -35815,9 +35831,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -35847,6 +35865,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -35894,6 +35913,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -35996,6 +36016,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -36059,9 +36080,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -36091,6 +36114,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36141,6 +36165,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -36243,6 +36268,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -36306,9 +36332,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -36338,6 +36366,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36388,6 +36417,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -36490,6 +36520,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -36553,9 +36584,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -36585,6 +36618,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36635,6 +36669,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -36737,6 +36772,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -36800,9 +36836,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -36832,6 +36870,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -36882,6 +36921,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -36984,6 +37024,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -37047,9 +37088,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -37079,6 +37122,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37129,6 +37173,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -37231,6 +37276,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -37294,9 +37340,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -37326,6 +37374,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37376,6 +37425,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -37478,6 +37528,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -37541,9 +37592,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -37573,6 +37626,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37623,6 +37677,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -37725,6 +37780,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -37791,9 +37847,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -37823,6 +37881,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -37873,6 +37932,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -37975,6 +38035,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -38038,9 +38099,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -38070,6 +38133,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38120,6 +38184,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -38222,6 +38287,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -38285,9 +38351,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -38317,6 +38385,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38367,6 +38436,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -38469,6 +38539,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -38532,9 +38603,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -38564,6 +38637,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38614,6 +38688,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -38716,6 +38791,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -38779,9 +38855,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -38811,6 +38889,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -38861,6 +38940,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -38963,6 +39043,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -39026,9 +39107,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -39058,6 +39141,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39108,6 +39192,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -39210,6 +39295,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -39273,9 +39359,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -39305,6 +39393,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39355,6 +39444,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -39457,6 +39547,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -39520,9 +39611,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -39552,6 +39645,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39559,6 +39653,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -39605,6 +39700,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -39707,6 +39803,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -39773,9 +39870,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -39805,6 +39904,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -39812,6 +39912,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -39858,6 +39959,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -39960,6 +40062,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -40026,9 +40129,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -40058,6 +40163,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40065,6 +40171,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -40111,6 +40218,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -40213,6 +40321,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -40279,9 +40388,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -40311,6 +40422,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40318,6 +40430,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -40364,6 +40477,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -40466,6 +40580,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -40532,9 +40647,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -40564,6 +40681,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40571,6 +40689,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -40617,6 +40736,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -40719,6 +40839,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -40782,9 +40903,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -40814,6 +40937,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -40864,6 +40988,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -40966,6 +41091,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -41029,9 +41155,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -41061,6 +41189,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41068,6 +41197,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -41114,6 +41244,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -41216,6 +41347,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -41279,9 +41411,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -41311,6 +41445,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41361,6 +41496,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -41463,6 +41599,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -41526,9 +41663,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -41558,6 +41697,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41608,6 +41748,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -41710,6 +41851,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -41773,9 +41915,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -41805,6 +41949,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -41812,6 +41957,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -41858,6 +42004,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -41960,6 +42107,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -42026,9 +42174,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -42058,6 +42208,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42065,6 +42216,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -42111,6 +42263,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -42213,6 +42366,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -42279,9 +42433,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -42311,6 +42467,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42318,6 +42475,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -42364,6 +42522,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -42466,6 +42625,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -42529,9 +42689,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -42561,6 +42723,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42568,6 +42731,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -42614,6 +42778,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -42716,6 +42881,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -42782,9 +42948,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -42814,6 +42982,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -42821,6 +42990,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -42867,6 +43037,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -42969,6 +43140,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -43035,9 +43207,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -43067,6 +43241,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43074,6 +43249,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -43120,6 +43296,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -43222,6 +43399,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -43288,9 +43466,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -43320,6 +43500,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43327,6 +43508,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -43373,6 +43555,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -43475,6 +43658,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -43541,9 +43725,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -43573,6 +43759,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43580,6 +43767,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -43626,6 +43814,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -43728,6 +43917,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -43794,9 +43984,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -43826,6 +44018,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -43833,6 +44026,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -43879,6 +44073,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -43981,6 +44176,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -44047,9 +44243,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -44079,6 +44277,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44086,6 +44285,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -44132,6 +44332,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -44234,6 +44435,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -44300,9 +44502,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -44332,6 +44536,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44339,6 +44544,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -44385,6 +44591,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -44487,6 +44694,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -44553,9 +44761,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -44585,6 +44795,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44592,6 +44803,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -44638,6 +44850,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -44740,6 +44953,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -44806,9 +45020,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -44838,6 +45054,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -44845,6 +45062,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -44891,6 +45109,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -44993,6 +45212,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -45059,9 +45279,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -45091,6 +45313,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45098,6 +45321,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -45144,6 +45368,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -45246,6 +45471,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -45312,9 +45538,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -45344,6 +45572,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45351,6 +45580,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -45397,6 +45627,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -45499,6 +45730,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -45565,9 +45797,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -45597,6 +45831,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45604,6 +45839,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -45650,6 +45886,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -45752,6 +45989,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -45818,9 +46056,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -45850,6 +46090,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -45857,6 +46098,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -45903,6 +46145,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -46005,6 +46248,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -46071,9 +46315,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -46103,6 +46349,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46110,6 +46357,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -46156,6 +46404,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -46258,6 +46507,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -46324,9 +46574,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -46356,6 +46608,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46363,6 +46616,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -46409,6 +46663,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -46510,6 +46765,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -46588,9 +46844,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -46620,6 +46878,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46627,6 +46886,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -46673,6 +46933,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -46775,6 +47036,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -46841,9 +47103,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -46873,6 +47137,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -46880,6 +47145,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -46926,6 +47192,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -47030,6 +47297,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -47108,9 +47376,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -47140,6 +47410,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47147,6 +47418,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -47193,6 +47465,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -47294,6 +47567,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -47372,9 +47646,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -47404,6 +47680,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47411,6 +47688,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -47457,6 +47735,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -47558,6 +47837,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -47636,9 +47916,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -47668,6 +47950,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47675,6 +47958,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -47721,6 +48005,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -47822,6 +48107,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -47900,9 +48186,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -47932,6 +48220,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -47939,6 +48228,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -47985,6 +48275,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -48086,6 +48377,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -48164,9 +48456,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -48196,6 +48490,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48203,6 +48498,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -48249,6 +48545,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -48354,6 +48651,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -48432,9 +48730,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -48464,6 +48764,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48471,6 +48772,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -48520,6 +48822,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -48625,6 +48928,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -48703,9 +49007,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -48735,6 +49041,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -48742,6 +49049,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -48791,6 +49099,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -48895,6 +49204,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -48973,9 +49283,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -49005,6 +49317,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49012,6 +49325,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -49058,6 +49372,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -49159,6 +49474,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -49237,9 +49553,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -49269,6 +49587,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49276,6 +49595,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -49322,6 +49642,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -49423,6 +49744,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -49501,9 +49823,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -49533,6 +49857,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49540,6 +49865,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -49586,6 +49912,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -49687,6 +50014,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -49765,9 +50093,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -49797,6 +50127,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -49804,6 +50135,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -49850,6 +50182,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -49955,6 +50288,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -50033,9 +50367,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -50065,6 +50401,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50072,6 +50409,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -50121,6 +50459,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -50226,6 +50565,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -50304,9 +50644,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -50336,6 +50678,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50343,6 +50686,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -50392,6 +50736,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -50497,6 +50842,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -50575,9 +50921,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -50607,6 +50955,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50614,6 +50963,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -50663,6 +51013,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -50768,6 +51119,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -50846,9 +51198,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -50879,6 +51233,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -50886,6 +51241,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -50935,6 +51291,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -51040,6 +51397,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -51118,9 +51476,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -51151,6 +51511,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51158,6 +51519,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -51207,6 +51569,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -51311,6 +51674,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -51389,9 +51753,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -51421,6 +51787,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51428,6 +51795,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -51474,6 +51842,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -51579,6 +51948,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -51657,9 +52027,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -51689,6 +52061,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51696,6 +52069,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -51745,6 +52119,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -51850,6 +52225,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -51928,9 +52304,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -51960,6 +52338,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -51967,6 +52346,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -52016,6 +52396,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -52121,6 +52502,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -52199,9 +52581,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -52231,6 +52615,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52238,6 +52623,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -52287,6 +52673,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -52392,6 +52779,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -52470,9 +52858,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -52503,6 +52893,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52510,6 +52901,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -52559,6 +52951,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -52664,6 +53057,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -52742,9 +53136,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -52775,6 +53171,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -52782,6 +53179,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -52831,6 +53229,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -52936,6 +53335,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -53018,9 +53418,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -53063,6 +53465,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53070,6 +53473,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -53119,6 +53523,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -53224,6 +53629,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -53306,9 +53712,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -53351,6 +53759,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53358,6 +53767,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -53407,6 +53817,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -53518,6 +53929,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -53600,9 +54012,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -53645,6 +54059,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53652,6 +54067,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -53701,12 +54117,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -53818,6 +54236,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -53900,9 +54319,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -53945,6 +54366,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -53952,6 +54374,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -54001,12 +54424,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -54118,6 +54543,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -54200,9 +54626,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -54245,6 +54673,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54252,6 +54681,7 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "etcd-arg": {
@@ -54301,12 +54731,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -54418,6 +54850,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -54496,9 +54929,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -54529,6 +54964,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54536,9 +54972,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -54588,6 +55026,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -54699,6 +55138,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -54781,9 +55221,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -54826,6 +55268,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -54833,9 +55276,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -54885,6 +55330,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -54996,6 +55442,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -55078,9 +55525,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -55123,6 +55572,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55130,9 +55580,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -55182,6 +55634,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -55299,6 +55752,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -55381,9 +55835,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -55426,6 +55882,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55433,9 +55890,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -55485,12 +55944,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -55608,6 +56069,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -55690,9 +56152,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -55735,6 +56199,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -55742,9 +56207,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -55802,12 +56269,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -55925,6 +56394,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -56007,9 +56477,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -56052,6 +56524,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56059,9 +56532,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -56119,12 +56594,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -56242,6 +56719,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -56324,9 +56802,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -56369,6 +56849,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56376,9 +56857,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -56436,12 +56919,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -56559,6 +57044,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -56641,9 +57127,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -56686,6 +57174,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56693,9 +57182,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -56753,12 +57244,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -56870,6 +57363,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -56948,9 +57442,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -56981,6 +57477,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -56988,9 +57485,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -57040,6 +57539,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -57151,6 +57651,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -57233,9 +57734,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -57278,6 +57781,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57285,9 +57789,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -57337,6 +57843,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -57448,6 +57955,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -57530,9 +58038,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -57575,6 +58085,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57582,9 +58093,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -57634,6 +58147,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -57745,6 +58259,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -57827,9 +58342,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -57872,6 +58389,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -57879,9 +58397,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -57931,6 +58451,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -58042,6 +58563,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -58124,9 +58646,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -58169,6 +58693,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58176,9 +58701,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -58236,6 +58763,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -58347,6 +58875,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -58429,9 +58958,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -58474,6 +59005,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58481,9 +59013,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -58541,6 +59075,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -58652,6 +59187,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -58734,9 +59270,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -58779,6 +59317,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -58786,9 +59325,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -58846,6 +59387,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -58957,6 +59499,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -59039,9 +59582,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -59084,6 +59629,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59091,9 +59637,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -59151,6 +59699,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -59262,6 +59811,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -59344,9 +59894,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -59389,6 +59941,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59396,9 +59949,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -59456,6 +60011,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -59567,6 +60123,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -59649,9 +60206,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -59694,6 +60253,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -59701,9 +60261,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -59761,6 +60323,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -59872,6 +60435,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -59958,9 +60522,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -60003,6 +60569,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60010,9 +60577,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -60070,6 +60639,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -60181,6 +60751,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -60267,9 +60838,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -60312,6 +60885,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60319,9 +60893,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -60379,6 +60955,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -60490,6 +61067,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -60576,9 +61154,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -60621,6 +61201,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60628,9 +61209,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -60688,6 +61271,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -60799,6 +61383,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -60881,9 +61466,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -60926,6 +61513,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -60933,9 +61521,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -60985,6 +61575,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
@@ -61102,6 +61693,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -61184,9 +61776,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -61229,6 +61823,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61236,9 +61831,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -61288,12 +61885,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -61411,6 +62010,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -61501,9 +62101,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -61546,6 +62148,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61553,9 +62156,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -61613,12 +62218,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -61736,6 +62343,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -61826,9 +62434,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -61871,6 +62481,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -61878,9 +62489,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -61938,12 +62551,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -62061,6 +62676,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -62151,9 +62767,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -62196,6 +62814,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62203,9 +62822,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -62263,12 +62884,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -62386,6 +63009,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -62476,9 +63100,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -62521,6 +63147,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62528,9 +63155,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -62588,12 +63217,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -62711,6 +63342,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -62801,9 +63433,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -62846,6 +63480,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -62853,9 +63488,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -62913,12 +63550,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -63036,6 +63675,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -63126,9 +63766,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -63171,6 +63813,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63178,9 +63821,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -63238,12 +63883,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -63361,6 +64008,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -63455,9 +64103,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -63500,6 +64150,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63507,9 +64158,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -63567,12 +64220,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -63690,6 +64345,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -63784,9 +64440,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -63829,6 +64487,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -63836,9 +64495,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -63896,12 +64557,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -64019,6 +64682,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -64113,9 +64777,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -64158,6 +64824,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64165,9 +64832,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -64225,12 +64894,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -64348,6 +65019,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -64439,9 +65111,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -64484,6 +65158,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64491,9 +65166,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -64551,12 +65228,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -64674,6 +65353,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -64768,9 +65448,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -64813,6 +65495,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -64820,9 +65503,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -64880,12 +65565,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -65003,6 +65690,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -65097,9 +65785,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -65142,6 +65832,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65149,9 +65840,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -65209,12 +65902,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -65332,6 +66027,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -65426,9 +66122,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -65471,6 +66169,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65478,9 +66177,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -65538,12 +66239,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -65661,6 +66364,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -65751,9 +66455,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -65796,6 +66502,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -65803,9 +66510,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -65863,12 +66572,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -65986,6 +66697,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -66076,9 +66788,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -66121,6 +66835,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66128,9 +66843,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -66188,12 +66905,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -66311,6 +67030,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -66401,9 +67121,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -66446,6 +67168,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66453,9 +67176,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -66513,12 +67238,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -66636,6 +67363,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -66726,9 +67454,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -66771,6 +67501,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -66778,9 +67509,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -66838,12 +67571,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -66961,6 +67696,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -67051,9 +67787,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -67096,6 +67834,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67103,9 +67842,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -67163,12 +67904,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -67286,6 +68029,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -67380,9 +68124,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -67425,6 +68171,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67432,9 +68179,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -67492,12 +68241,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -67615,6 +68366,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -67709,9 +68461,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -67754,6 +68508,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -67761,9 +68516,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -67821,12 +68578,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -67944,6 +68703,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -68038,9 +68798,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -68083,6 +68845,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68090,9 +68853,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -68150,12 +68915,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -68273,6 +69040,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -68364,9 +69132,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -68409,6 +69179,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68416,9 +69187,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -68476,12 +69249,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -68599,6 +69374,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -68693,9 +69469,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -68738,6 +69516,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -68745,9 +69524,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -68805,12 +69586,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -68928,6 +69711,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -69022,9 +69806,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -69067,6 +69853,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69074,9 +69861,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -69134,12 +69923,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -69257,6 +70048,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -69351,9 +70143,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -69396,6 +70190,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69403,9 +70198,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -69463,12 +70260,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -69586,6 +70385,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -69680,9 +70480,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -69725,6 +70527,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -69732,9 +70535,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -69792,12 +70597,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -69939,6 +70746,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -70033,9 +70841,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -70078,6 +70888,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70085,9 +70896,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -70151,6 +70964,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -70160,6 +70974,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -70283,6 +71098,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -70377,9 +71193,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -70422,6 +71240,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70429,9 +71248,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -70489,12 +71310,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -70612,6 +71435,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -70706,9 +71530,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -70751,6 +71577,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -70758,9 +71585,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -70818,12 +71647,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -70941,6 +71772,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -71035,9 +71867,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -71080,6 +71914,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71087,9 +71922,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -71147,12 +71984,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -71270,6 +72109,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -71361,9 +72201,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -71406,6 +72248,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71413,9 +72256,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -71473,12 +72318,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -71596,6 +72443,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -71690,9 +72538,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -71735,6 +72585,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -71742,9 +72593,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -71802,12 +72655,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -71925,6 +72780,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -72019,9 +72875,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -72064,6 +72922,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72071,9 +72930,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -72131,12 +72992,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -72254,6 +73117,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -72348,9 +73212,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -72393,6 +73259,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72400,9 +73267,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -72460,12 +73329,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -72583,6 +73454,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -72677,9 +73549,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -72722,6 +73596,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -72729,9 +73604,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -72789,12 +73666,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -72936,6 +73815,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -73030,9 +73910,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -73075,6 +73957,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73082,9 +73965,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -73148,6 +74033,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -73157,6 +74043,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -73304,6 +74191,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -73398,9 +74286,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -73443,6 +74333,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73450,9 +74341,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -73516,6 +74409,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -73525,6 +74419,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -73672,6 +74567,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -73766,9 +74662,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -73811,6 +74709,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -73818,9 +74717,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -73884,6 +74785,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -73893,6 +74795,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -74040,6 +74943,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -74134,9 +75038,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -74179,6 +75085,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74186,9 +75093,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -74252,6 +75161,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -74261,6 +75171,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -74408,6 +75319,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -74502,9 +75414,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -74547,6 +75461,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74554,9 +75469,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -74620,6 +75537,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -74629,6 +75547,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -74776,6 +75695,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -74870,9 +75790,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -74915,6 +75837,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -74922,9 +75845,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -74988,6 +75913,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -74997,6 +75923,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -75123,6 +76050,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -75214,9 +76142,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -75259,6 +76189,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75266,9 +76197,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -75326,12 +76259,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -75452,6 +76387,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -75546,9 +76482,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -75591,6 +76529,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75598,9 +76537,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -75658,12 +76599,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -75784,6 +76727,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -75878,9 +76822,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -75923,6 +76869,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -75930,9 +76877,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -75990,12 +76939,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -76116,6 +77067,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -76210,9 +77162,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -76255,6 +77209,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76262,9 +77217,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -76322,12 +77279,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -76448,6 +77407,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -76542,9 +77502,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -76587,6 +77549,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76594,9 +77557,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "etcd-arg": {
@@ -76654,12 +77619,14 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "snapshotter": {
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -76804,6 +77771,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -76898,9 +77866,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -76943,6 +77913,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -76950,9 +77921,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -77016,6 +77989,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -77025,6 +77999,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -77175,6 +78150,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -77269,9 +78245,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -77314,6 +78292,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -77321,9 +78300,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -77387,6 +78368,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -77396,6 +78378,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -77546,6 +78529,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -77640,9 +78624,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -77685,6 +78671,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -77692,9 +78679,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -77758,6 +78747,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -77767,6 +78757,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -77917,6 +78908,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -78011,9 +79003,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -78056,6 +79050,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78063,9 +79058,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -78129,6 +79126,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -78138,6 +79136,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -78288,6 +79287,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -78382,9 +79382,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -78427,6 +79429,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78434,9 +79437,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -78500,6 +79505,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -78509,6 +79515,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -78659,6 +79666,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -78753,9 +79761,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -78798,6 +79808,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -78805,9 +79816,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -78871,6 +79884,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -78880,6 +79894,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -79030,6 +80045,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -79124,9 +80140,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -79169,6 +80187,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79176,9 +80195,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -79245,6 +80266,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -79254,6 +80276,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -79404,6 +80427,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -79498,9 +80522,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -79543,6 +80569,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79550,9 +80577,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -79619,6 +80648,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -79628,6 +80658,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -79778,6 +80809,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -79872,9 +80904,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -79917,6 +80951,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -79924,9 +80959,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -79993,6 +81030,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -80002,6 +81040,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -80152,6 +81191,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -80246,9 +81286,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -80291,6 +81333,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -80298,9 +81341,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -80367,6 +81412,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -80376,6 +81422,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -80526,6 +81573,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -80620,9 +81668,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -80665,6 +81715,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -80672,9 +81723,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -80741,6 +81794,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -80750,6 +81804,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -80900,6 +81955,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -80994,9 +82050,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -81039,6 +82097,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81046,9 +82105,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -81118,6 +82179,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -81127,6 +82189,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -81277,6 +82340,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -81371,9 +82435,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -81416,6 +82482,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81423,9 +82490,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -81489,6 +82558,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -81498,6 +82568,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -81648,6 +82719,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -81742,9 +82814,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -81787,6 +82861,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -81794,9 +82869,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -81860,6 +82937,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -81869,6 +82947,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -82019,6 +83098,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -82113,9 +83193,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -82158,6 +83240,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82165,9 +83248,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -82231,6 +83316,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -82240,6 +83326,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -82390,6 +83477,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -82484,9 +83572,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -82529,6 +83619,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82536,9 +83627,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -82602,6 +83695,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -82611,6 +83705,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -82761,6 +83856,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -82855,9 +83951,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -82900,6 +83998,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -82907,9 +84006,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -82973,6 +84074,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -82982,6 +84084,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -83132,6 +84235,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -83226,9 +84330,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -83271,6 +84377,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -83278,9 +84385,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -83344,6 +84453,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -83353,6 +84463,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -83503,6 +84614,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -83597,9 +84709,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -83642,6 +84756,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -83649,9 +84764,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -83718,6 +84835,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -83727,6 +84845,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -83877,6 +84996,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -83971,9 +85091,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -84016,6 +85138,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84023,9 +85146,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -84092,6 +85217,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -84101,6 +85227,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -84251,6 +85378,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -84345,9 +85473,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -84390,6 +85520,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84397,9 +85528,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -84466,6 +85599,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -84475,6 +85609,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -84625,6 +85760,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -84719,9 +85855,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -84764,6 +85902,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -84771,9 +85910,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -84840,6 +85981,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -84849,6 +85991,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -84999,6 +86142,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -85093,9 +86237,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -85138,6 +86284,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85145,9 +86292,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -85214,6 +86363,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -85223,6 +86373,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -85373,6 +86524,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -85467,9 +86619,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -85512,6 +86666,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85519,9 +86674,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -85591,6 +86748,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -85600,6 +86758,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -85750,6 +86909,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -85844,9 +87004,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -85889,6 +87051,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -85896,9 +87059,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -85962,6 +87127,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -85971,6 +87137,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -86121,6 +87288,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -86215,9 +87383,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -86260,6 +87430,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -86267,9 +87438,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -86333,6 +87506,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -86342,6 +87516,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -86492,6 +87667,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -86586,9 +87762,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -86631,6 +87809,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -86638,9 +87817,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -86704,6 +87885,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -86713,6 +87895,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -86863,6 +88046,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -86957,9 +88141,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -87002,6 +88188,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87009,9 +88196,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -87075,6 +88264,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -87084,6 +88274,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -87234,6 +88425,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -87328,9 +88520,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -87373,6 +88567,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87380,9 +88575,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -87449,6 +88646,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -87458,6 +88656,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -87608,6 +88807,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -87702,9 +88902,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -87747,6 +88949,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -87754,9 +88957,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -87823,6 +89028,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -87832,6 +89038,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -87982,6 +89189,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -88076,9 +89284,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -88121,6 +89331,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88128,9 +89339,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -88197,6 +89410,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -88206,6 +89420,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -88356,6 +89571,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -88450,9 +89666,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -88495,6 +89713,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88502,9 +89721,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -88571,6 +89792,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -88580,6 +89802,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -88730,6 +89953,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -88824,9 +90048,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -88869,6 +90095,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -88876,9 +90103,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -88945,6 +90174,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -88954,6 +90184,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -89104,6 +90335,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -89198,9 +90430,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -89243,6 +90477,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -89250,9 +90485,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -89322,6 +90559,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -89331,6 +90569,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -89481,6 +90720,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -89579,9 +90819,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -89624,6 +90866,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -89631,9 +90874,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -89700,6 +90945,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -89709,6 +90955,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -89859,6 +91106,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -89957,9 +91205,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -90002,6 +91252,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -90009,9 +91260,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -90078,6 +91331,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -90087,6 +91341,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {
@@ -90237,6 +91492,7 @@
       "type": "bool"
      },
      "system-default-registry": {
+      "agentRestart": true,
       "type": "string"
      }
     },
@@ -90335,9 +91591,11 @@
       "type": "string"
      },
      "cluster-dns": {
+      "agentRestart": true,
       "type": "string"
      },
      "cluster-domain": {
+      "agentRestart": true,
       "type": "string"
      },
      "cni": {
@@ -90380,6 +91638,7 @@
       "type": "bool"
      },
      "disable-kube-proxy": {
+      "agentRestart": true,
       "default": false,
       "type": "boolean"
      },
@@ -90387,9 +91646,11 @@
       "type": "bool"
      },
      "egress-selector-mode": {
+      "agentRestart": true,
       "type": "string"
      },
      "embedded-registry": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "enable-servicelb": {
@@ -90459,6 +91720,7 @@
       "type": "string"
      },
      "service-node-port-range": {
+      "agentRestart": true,
       "type": "string"
      },
      "servicelb-namespace": {
@@ -90468,6 +91730,7 @@
       "type": "string"
      },
      "supervisor-metrics": {
+      "agentRestart": true,
       "type": "boolean"
      },
      "tls-san": {


### PR DESCRIPTION
  Part of https://github.com/rancher/rancher/issues/55326

  Adds `agentRestart: true` to the `disable-kube-proxy` serverArg. Marks the flag as one whose
  change requires affected agents to restart. Second commit is the regenerated `data.json`.

  Related:
  - Channelserver: https://github.com/rancher/channelserver/pull/45
  - Rancher: https://github.com/rancher/rancher/pull/56603