### PR TITLE
[dev-v2.16] updates for v2.16

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,14 @@
   "packageRules": [
     {
       "matchBaseBranches": [
+        "dev-v2.15"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.15#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
         "dev-v2.14"
       ],
       "extends": [

--- a/.github/workflows/daily-version-check.yml
+++ b/.github/workflows/daily-version-check.yml
@@ -37,6 +37,8 @@ jobs:
             release_branch: release-v2.13
           - dev_branch: dev-v2.14
             release_branch: release-v2.14
+          - dev_branch: dev-v2.15
+            release_branch: release-v2.15
           - dev_branch: dev-v2.11-rke-extended-life
             release_branch: release-v2.11-rke-extended-life
 

--- a/.github/workflows/provisioning-tests.yaml
+++ b/.github/workflows/provisioning-tests.yaml
@@ -121,7 +121,7 @@ jobs:
           KDM_TEST_K8S_MINOR: ${{ matrix.k8s-minor }}
           PREV_COMMIT_PR_SHA: ${{ github.event.pull_request.base.sha }}
           PREV_COMMIT_PUSH_SHA: ${{ github.event.before }}
-          CATTLE_AGENT_IMAGE: "rancher/rancher-agent:head" # TODO: change to v2.16-head after v2.16.0 is released
+          CATTLE_AGENT_IMAGE: "rancher/rancher-agent:v2.15-head" # TODO: change to v2.16-head after v2.16.0 is released
       - name: Move plaintext test results for upload
         if: always()
         id: test_output

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,8 +1,8 @@
-ARG RANCHER_VERSION=v2.14-head
+ARG RANCHER_VERSION=v2.15-head
 
 FROM rancher/rancher:$RANCHER_VERSION AS rancher
 
-FROM registry.suse.com/bci/golang:1.25
+FROM registry.suse.com/bci/golang:1.26
 
 # --- Tool installations (most expensive, no dependency on rancher content) ---
 ARG TARGETARCH=amd64

--- a/scripts/fetch-provisioning-tests
+++ b/scripts/fetch-provisioning-tests
@@ -12,7 +12,7 @@ TMP_DIR=$(TMPDIR=/var/tmp mktemp -d)
 pushd "$TMP_DIR"
 
 IMAGE_REPO=${IMAGE_REPO:-rancher/rancher}
-IMAGE_TAG=${IMAGE_TAG:-v2.14-head}
+IMAGE_TAG=${IMAGE_TAG:-v2.15-head}
 IMAGE=${IMAGE:-$IMAGE_REPO:$IMAGE_TAG}
 
 # Inspect image, get server version and extract rancher commit 
@@ -29,7 +29,7 @@ mkdir -p rancher
 # Although using the commit so the image matches the source code, use the default branch associated with that release line
 # Git clones must have a branch, and the release branch is likely to contain the commit anyway
 GIT_URL=${GIT_URL:-https://github.com/rancher/rancher.git}
-GIT_BRANCH=${GIT_BRANCH:-release/v2.14}
+GIT_BRANCH=${GIT_BRANCH:-release/v2.15}
 
 git clone --depth 1 -b $GIT_BRANCH $GIT_URL ./rancher
 

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -109,5 +109,5 @@ cd "$RANCHER_DIR"
 # Remove superfluous check for UI only bumps in this context
 sed -i -e '3,5d' ./scripts/provisioning-tests
 
-export CATTLE_AGENT_IMAGE=${CATTLE_AGENT_IMAGE:-rancher/rancher-agent:v2.14-head}
+export CATTLE_AGENT_IMAGE=${CATTLE_AGENT_IMAGE:-rancher/rancher-agent:v2.15-head}
 ./scripts/provisioning-tests

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -24,4 +24,4 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Checking if released versions are not changed
-go run ./cmd/validation/ release-v2.14
+go run ./cmd/validation/ release-v2.15


### PR DESCRIPTION
Updates several CI files to point to Rancher v2.15 instead of Rancher v2.14. AFAIK we cannot update to v2.16 yet as we do not publish `v2.16-head` for either the rancher/rancher image or the rancher/rancher-agent image. 

After looking through the logs of the failing tests in dev-v2.16 I'm fairly confident the issue was related to the new rancher-agent charts init container that was added in 2.15. By pulling Rancher v2.14 for the server, but running the `head` version of the rancher-agent, we ran into a situation where the init-container was never present on the agent manifest so the agent failed to start / connect to Rancher. After pointing the agent to `v2.15-head` in this PR the tests are now passing as expected, as you can see [here](https://github.com/rancher/kontainer-driver-metadata/actions/runs/34392591510/job/102605384974?pr=2193) 

## Testing

I added a [temporary commit](https://github.com/rancher/kontainer-driver-metadata/commit/d9722a46a950bd31408e4ce6df1d675eb1aa8b68) to execute the provisioning tests for 1.36, which showed that they should pass the next time a valid KDM update it made to `dev-v2.16`

validation step seems to be failing, this is potentially due to some 2.15 releases not being forward ported into 2.16. Unfortunately there isn't a release branch for 2.16 yet